### PR TITLE
[FEAT] 회원가입 페이지 UI 구현

### DIFF
--- a/src/main/webapp/WEB-INF/views/user/login.jsp
+++ b/src/main/webapp/WEB-INF/views/user/login.jsp
@@ -33,7 +33,7 @@
         </form>
         
         <div class="link-area">
-            <a href="#" class="signup-link">회원가입</a> |
+            <a href="/user/signupPage" class="signup-link">회원가입</a> |
             <a href="#" class="find-link">아이디/비밀번호 찾기</a>
         </div>
     </div>

--- a/src/main/webapp/WEB-INF/views/user/signup.jsp
+++ b/src/main/webapp/WEB-INF/views/user/signup.jsp
@@ -1,0 +1,57 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Insert title here</title>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<link href="<c:url value="/resources/css/login.css"/>" rel="stylesheet">
+<!-- axios -->
+<script type="module" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+</head>
+<body>
+	<div class="login-container signup-container">
+        
+        <a href="<c:url value='/'/>" class="home-link">
+            <h1 class="login-title">자동 채점 서비스</h1>
+        </a>
+        
+        <p class="login-subtitle">새로운 계정을 만들고 학습 관리 서비스를 이용해 보세요.</p>
+        
+        <form action="/auth/signup" method="post" class="login-form">
+            
+            <div class="input-group">
+                <label for="userId" class="input-label">아이디</label>
+                <div class="input-with-button">
+                    <input type="text" id="userId" name="userId" class="input-field" placeholder="아이디 (4~12자)" required>
+                    <button type="button" class="check-button">중복 확인</button>
+                </div>
+            </div>
+            
+            <div class="input-group">
+                <label for="password" class="input-label">비밀번호</label>
+                <input type="password" id="password" name="password" class="input-field" placeholder="비밀번호 입력" required>
+            </div>
+            
+            <div class="input-group">
+                <label for="passwordCheck" class="input-label">비밀번호 확인</label>
+                <input type="password" id="passwordCheck" name="passwordCheck" class="input-field" placeholder="비밀번호 재확인" required>
+            </div>
+            
+            <div class="input-group">
+                <label for="email" class="input-label">이메일</label>
+                <input type="email" id="email" name="email" class="input-field" placeholder="이메일 주소" required>
+            </div>
+            
+            <button type="submit" class="login-button signup-button">가입 완료</button>
+        </form>
+        
+        <div class="link-area">
+            이미 계정이 있으신가요? <a href="<c:url value='/user/login'/>" class="signup-link">로그인</a>
+        </div>
+    </div>
+
+	<script src="<c:url value="/resources/js/signup.js"/>"></script>
+</body>
+</html>

--- a/src/main/webapp/resources/css/login.css
+++ b/src/main/webapp/resources/css/login.css
@@ -113,6 +113,35 @@ body {
     text-decoration: underline;
 }
 
+/* 회원가입 */
+.signup-container {
+    max-width: 450px; 
+}
+
+/* 아이디 중복 확인 버튼을 포함하는 입력 그룹 */
+.input-with-button {
+    display: flex;
+    gap: 8px; /* 입력창과 버튼 사이 간격 */
+}
+
+/* 중복 확인 버튼 스타일 */
+.check-button {
+    flex-shrink: 0; 
+    padding: 12px 15px;
+    border: none;
+    border-radius: 6px;
+    background-color: #95a5a6;
+    color: #fff;
+    font-size: 0.9em;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.check-button:hover {
+    background-color: #7f8c8d;
+}
+
 /* 반응형 디자인 */
 @media (max-width: 450px) {
     .login-container {
@@ -121,5 +150,12 @@ body {
     }
     .login-title {
         font-size: 1.5em;
+    }
+    .input-with-button {
+        flex-direction: column;
+    }
+    .check-button {
+        width: 100%;
+        margin-top: 5px;
     }
 }


### PR DESCRIPTION
## 📌 변경 사항
- 회원가입 페이지 UI 구현
- 회원가입 페이지에 아이디, 비밀번호(2회), 이메일 입력 필드 및 아이디 중복 확인 버튼 배치
- 페이지 제목을 메인 페이지로 이동하는 링크로 설정
- 로그인 페이지로 돌아갈 수 있는 링크를 하단에 추가

## 🛠️ 수정한 이유
- 회원 기능 확장 기반 마련: 추후 오답노트, 학습 관리 등 개인화된 기능을 사용자에게 제공하기 위해 필수적인 회원가입 기능 구현
- 운영 준비: 사용자 외 관리자도 회원으로 가입하여 시험 문제 등록 및 수정 관리자 페이지를 사용할 수 있도록 기반 마련

## 🔍 주요 변경 파일
- signup.jsp
- login.css

## ✅ 테스트 내용
- [x] `/user/signup` (`GET`) 접속 시 회원가입 페이지 UI 정상 표시 확인
- [x] 아이디, 비밀번호, 이메일 입력 필드와 중복 확인 버튼이 정상적으로 표시되는지 확인
- [x] 제목 클릭 시 메인 페이지로, 하단 링크 클릭 시 로그인 페이지로 정상 이동하는지 확인
- [x] 기존 로그인 페이지 UI가 영향을 받지 않는지 확인

## 🔗 관련 이슈
closes #5 
