### PR TITLE
[FEAT] 크롤링된 데이터 파싱 모듈 개발 v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,20 @@
 		    <artifactId>google-cloud-storage</artifactId>
 		    <version>2.54.0</version>
 		</dependency>
+		
+		<!-- google-cloud-vision -->
+		<dependency>
+		    <groupId>com.google.cloud</groupId>
+		    <artifactId>google-cloud-vision</artifactId>
+		    <version>3.74.0</version>
+		</dependency>
+		
+		<!-- spring-boot-devtools -->
+		<dependency>
+		    <groupId>org.springframework.boot</groupId>
+		    <artifactId>spring-boot-devtools</artifactId>
+		    <version>4.0.0-M3</version>
+		</dependency>
 	
 	</dependencies>
     <build>

--- a/src/main/java/com/my/ex/dao/ExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/ExamSelectionDao.java
@@ -7,6 +7,7 @@ import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import com.my.ex.dto.ExamChoiceDto;
 import com.my.ex.dto.ExamInfoDto;
 import com.my.ex.dto.ExamTypeDto;
 
@@ -31,6 +32,26 @@ public class ExamSelectionDao implements IExamSelectionDao {
 	@Override
 	public List<String> getExamSubjects(Map<String, String> map) {
 		return session.selectList(NAMESPACE + "getExamSubjects", map);
+	}
+	
+	@Override
+	public int checkExistingExamInfo(ExamInfoDto examInfo) {
+		return session.selectOne(NAMESPACE + "checkExistingExamInfo", examInfo);
+	}
+	
+	@Override
+	public void saveParsedExamInfo(ExamInfoDto examInfo) {
+		session.insert(NAMESPACE + "saveParsedExamInfo", examInfo);
+	}
+
+	@Override
+	public void saveParsedQuestionInfo(Map<String, Object> question) {
+		session.insert(NAMESPACE + "saveParsedQuestionInfo", question);
+	}
+
+	@Override
+	public int saveParsedChoiceInfo(ExamChoiceDto option) {
+		return session.insert(NAMESPACE + "saveParsedChoiceInfo", option);
 	}
 
 }

--- a/src/main/java/com/my/ex/dao/IExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/IExamSelectionDao.java
@@ -3,6 +3,7 @@ package com.my.ex.dao;
 import java.util.List;
 import java.util.Map;
 
+import com.my.ex.dto.ExamChoiceDto;
 import com.my.ex.dto.ExamInfoDto;
 import com.my.ex.dto.ExamTypeDto;
 
@@ -10,4 +11,8 @@ public interface IExamSelectionDao {
 	List<ExamTypeDto> getExamTypes();
 	List<String> getExamRounds(String examTypeCode);
 	List<String> getExamSubjects(Map<String, String> map);
+	int checkExistingExamInfo(ExamInfoDto examInfo);
+	void saveParsedExamInfo(ExamInfoDto examInfo);
+	void saveParsedQuestionInfo(Map<String, Object> question);
+	int saveParsedChoiceInfo(ExamChoiceDto option);
 }

--- a/src/main/java/com/my/ex/dao/IUserDao.java
+++ b/src/main/java/com/my/ex/dao/IUserDao.java
@@ -1,5 +1,6 @@
 package com.my.ex.dao;
 
+
 import com.my.ex.dto.UserDto;
 
 public interface IUserDao {

--- a/src/main/java/com/my/ex/dao/UserDao.java
+++ b/src/main/java/com/my/ex/dao/UserDao.java
@@ -1,5 +1,6 @@
 package com.my.ex.dao;
 
+
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -28,5 +29,5 @@ public class UserDao implements IUserDao {
 	public int checkIdDuplicate(String checkId) {
 		return session.selectOne(NAMESPACE + "checkIdDuplicate", checkId);
 	}
-	
+
 }

--- a/src/main/java/com/my/ex/dto/ExamAnswerDto.java
+++ b/src/main/java/com/my/ex/dto/ExamAnswerDto.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class ExamAnswerDto {
-	private int answerId; // pk
-	private int questionId; // exam_question fk
-	private String correctLabel; // 정답 선택지 식별자(①, ②, ③)
+	private int answerId; 			// pk
+	private int questionId; 		// exam_question fk
+	private String correctLabel;	// 정답 선택지 식별자(①, ②, ③)
 }

--- a/src/main/java/com/my/ex/dto/ExamChoiceDto.java
+++ b/src/main/java/com/my/ex/dto/ExamChoiceDto.java
@@ -1,12 +1,20 @@
 package com.my.ex.dto;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class ExamChoiceDto {
-	private int choiceId; // pk
-	private int questionId; // exam_question fk
+	private int choiceId; 		// pk
+	private int questionId; 	// exam_question fk
 	private String choiceLabel; // 선택지 식별자(①, ②, ③)
-	private String choiceText; // 선택지 내용
-	private String choiceImage; // 선택지 이미지 URL(있으면)
+	private String choiceText; 	// 선택지 내용
+	private String choiceImage;	// 선택지 이미지 URL(있으면)
+	
+	public ExamChoiceDto(String choiceLabel, String choiceText) {
+		this.choiceLabel = choiceLabel;
+		this.choiceText = choiceText;
+	}
+
 }

--- a/src/main/java/com/my/ex/dto/ExamInfoDto.java
+++ b/src/main/java/com/my/ex/dto/ExamInfoDto.java
@@ -4,8 +4,16 @@ import lombok.Data;
 
 @Data
 public class ExamInfoDto {
-	private int examId; // pk
-	private int examTypeId; // exam_type fk
-	private String examRound; // 시험 회차
+	private int examId;			// pk
+	private int examTypeId; 	// 시험 종류
+	private String examRound; 	// 시험 회차
 	private String examSubject; // 시험 과목
+	private String sessionNo; 	// 시험 교시
+	
+	public ExamInfoDto(String examRound, String examSubject, String sessionNo) {
+		this.examRound = examRound;
+		this.examSubject = examSubject;
+		this.sessionNo = sessionNo;
+	}
+	
 }

--- a/src/main/java/com/my/ex/dto/ExamQuestionDto.java
+++ b/src/main/java/com/my/ex/dto/ExamQuestionDto.java
@@ -5,11 +5,11 @@ import lombok.Data;
 @Data
 public class ExamQuestionDto {
 	private int questionId;
-	private int examId; // exam_info fk
-	private String sessionNo; // 교시
-	private int questionNum; // 문제 번호
-	private String questionText; // 문제 내용
-	private String questionImage; // 문제 이미지 URL
+	private int examId; 			// exam_info fk
+	private String sessionNo; 		// 교시
+	private int questionNum; 		// 문제 번호
+	private String questionText; 	// 문제 내용
+	private String questionImage; 	// 문제 이미지 URL
 	private String questionPassage; // 문제 지문 텍스트
-	private String passageScope; // 지문 적용 범위 (예: [11~13])
+	private String passageScope; 	// 지문 적용 범위 (예: [11~13])
 }

--- a/src/main/java/com/my/ex/parser/ExamInfo.java
+++ b/src/main/java/com/my/ex/parser/ExamInfo.java
@@ -5,6 +5,7 @@ import lombok.Data;
 // 파싱된 시험 기본 정보를 담기 위한 클래스
 @Data
 public class ExamInfo {
+	private int examTypeId; // 시험 종류
 	private String examRound; // 시험 회차
 	private String examSubject; // 시험 과목
 	private String sessionNo; // 시험 교시
@@ -14,6 +15,5 @@ public class ExamInfo {
 		this.examSubject = examSubject;
 		this.sessionNo = sessionNo;
 	}
-	
 	
 }

--- a/src/main/java/com/my/ex/parser/GedExamParser.java
+++ b/src/main/java/com/my/ex/parser/GedExamParser.java
@@ -1,20 +1,22 @@
 package com.my.ex.parser;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.my.ex.dto.ExamChoiceDto;
+import com.my.ex.dto.ExamInfoDto;
 
 public class GedExamParser implements IExamParser {
 
-	// ①, ②, ③, ④ 유니코드 패턴
-    private static final String CHOICE_PATTERN_STR = "(\u2460|\u2461|\u2462|\u2463)(.*?)";
-    private static final Pattern CHOICE_PATTERN = Pattern.compile(CHOICE_PATTERN_STR, Pattern.DOTALL);
-	
-    
     // 1. 페이지 상단 헤더 제거 패턴 (초졸/중졸/고졸 모두 대응)
     private static final Pattern PAGE_HEADER_PATTERN =
     	Pattern.compile("(초졸|중졸|고졸)\\s*\\([가-힣\\s]+\\)\\s*\\d+－\\d+", Pattern.DOTALL);
@@ -29,10 +31,75 @@ public class GedExamParser implements IExamParser {
     		Pattern.DOTALL
 		);
     
-    private ExamInfo examInfo;
+    // 자주 오인식되는 단어를 올바른 단어로 매핑하는 Map
+    private static final Map<String, String> CORRECTION_MAP = createCorrectionMap();
+    private static Map<String, String> createCorrectionMap(){
+    	return Collections.unmodifiableMap(Stream.of(
+			new AbstractMap.SimpleImmutableEntry<>("윗관","윗글"),
+			new AbstractMap.SimpleImmutableEntry<>("윁윈","적절"),
+			new AbstractMap.SimpleImmutableEntry<>("아윀씨","아저씨"),
+			new AbstractMap.SimpleImmutableEntry<>("윐수","점수"),
+			new AbstractMap.SimpleImmutableEntry<>("만윐","만점"),
+			new AbstractMap.SimpleImmutableEntry<>("묑줄","밑줄"),
+			new AbstractMap.SimpleImmutableEntry<>("한관","한글"),
+			new AbstractMap.SimpleImmutableEntry<>("김치쬌게","김치찌개"),
+			new AbstractMap.SimpleImmutableEntry<>("공통윐","공통점"),
+			new AbstractMap.SimpleImmutableEntry<>("문법윁","문법적"),
+			new AbstractMap.SimpleImmutableEntry<>("윀것","저것"),
+			new AbstractMap.SimpleImmutableEntry<>("어괋나는","어긋나는"),
+			new AbstractMap.SimpleImmutableEntry<>("중괈속","중금속"),
+			new AbstractMap.SimpleImmutableEntry<>("먼윀","먼저"),
+			new AbstractMap.SimpleImmutableEntry<>("미각윁","미각적"),
+			new AbstractMap.SimpleImmutableEntry<>("씁변","영변"),
+			new AbstractMap.SimpleImmutableEntry<>("너물","눈물"),
+			new AbstractMap.SimpleImmutableEntry<>("물질주의윁","물질주의적"),
+			new AbstractMap.SimpleImmutableEntry<>("위통윁인","전통적인"),
+			new AbstractMap.SimpleImmutableEntry<>("계승하씀기에","계승하였기에"),
+			new AbstractMap.SimpleImmutableEntry<>("위날","전날"),
+			new AbstractMap.SimpleImmutableEntry<>("딐","또"),
+			new AbstractMap.SimpleImmutableEntry<>("괈시에","금시에"),
+			new AbstractMap.SimpleImmutableEntry<>("지위을", "지전을"),
+			new AbstractMap.SimpleImmutableEntry<>("지위", "지전"),
+			new AbstractMap.SimpleImmutableEntry<>("윑은", "접은"),
+			new AbstractMap.SimpleImmutableEntry<>("잡픀", "잡혀"),
+			new AbstractMap.SimpleImmutableEntry<>("관을", "글을"),
+			new AbstractMap.SimpleImmutableEntry<>("관이", "글이"),
+			new AbstractMap.SimpleImmutableEntry<>("윑어서", "접어서"),
+			new AbstractMap.SimpleImmutableEntry<>("계윈", "계절"),
+			new AbstractMap.SimpleImmutableEntry<>("구체윁인", "구체적인"),
+			new AbstractMap.SimpleImmutableEntry<>("위개", "전개"),
+			new AbstractMap.SimpleImmutableEntry<>("표프", "표현"),
+			new AbstractMap.SimpleImmutableEntry<>("위달", "전달"),
+			new AbstractMap.SimpleImmutableEntry<>("사딐", "사또"),
+			new AbstractMap.SimpleImmutableEntry<>("하씀", "하였"),
+			new AbstractMap.SimpleImmutableEntry<>("일뜀다", "일렀다"),
+			new AbstractMap.SimpleImmutableEntry<>("그뜁그뜁", "그렁그렁"),
+			new AbstractMap.SimpleImmutableEntry<>("윈벽", "절벽"),
+			new AbstractMap.SimpleImmutableEntry<>("너이", "눈이"),
+			new AbstractMap.SimpleImmutableEntry<>("빙괋", "빙긋"),
+			new AbstractMap.SimpleImmutableEntry<>("윀녁", "저녁"),
+			new AbstractMap.SimpleImmutableEntry<>("윁시며", "적시며"),
+			new AbstractMap.SimpleImmutableEntry<>("세계윁", "세계적"),
+			new AbstractMap.SimpleImmutableEntry<>("강제윁", "강제적"),
+			new AbstractMap.SimpleImmutableEntry<>("프황", "현황"),
+			new AbstractMap.SimpleImmutableEntry<>("씁향", "영향"),
+			new AbstractMap.SimpleImmutableEntry<>("픑력", "협력"),
+			new AbstractMap.SimpleImmutableEntry<>("남종씁", "남종영"),
+			new AbstractMap.SimpleImmutableEntry<>("부정윁인", "부정적인"),
+			new AbstractMap.SimpleImmutableEntry<>("일반윁", "일반적"),
+			new AbstractMap.SimpleImmutableEntry<>("그뜇지", "그렇지"),
+			new AbstractMap.SimpleImmutableEntry<>("윁게", "적게"),
+			new AbstractMap.SimpleImmutableEntry<>("너코", "눈코"),
+			new AbstractMap.SimpleImmutableEntry<>("윀렴한", "저렴한"),
+			new AbstractMap.SimpleImmutableEntry<>("오위", "오후"),
+			new AbstractMap.SimpleImmutableEntry<>("위픑", "위협")
+		).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+    
+    private ExamInfoDto examInfo;
     
     @Override
-	public ExamInfo getExamInfo() {
+	public ExamInfoDto getExamInfo() {
 		return examInfo;
 	}
     
@@ -48,174 +115,263 @@ public class GedExamParser implements IExamParser {
 	// 시험 문제 번호와 문제+지문+선택지 추출
 	private List<Map<String, Object>> parseQuestions(String cleanedText) {
 		List<Map<String, Object>> questions = new ArrayList<>();
-		
-		String tempText = cleanedText.replaceAll("(?<=[^\\s])\\s*(\\d+\\.\\s*+)(?![\\d\\.])", "\n$1");
-		
-		Matcher firstQuestionMatcher = Pattern.compile("^.*?(?=\\s*1\\.\\s*)", Pattern.DOTALL).matcher(tempText);
-		String startText = tempText;
-	    if (firstQuestionMatcher.find()) {
-	        startText = tempText.substring(firstQuestionMatcher.end()).trim();
-	    }
-		
-		// 문제 단위 분리
+
+	    String tempText = cleanedText.replaceAll("(?<=[^\\s])\\s*(\\d+\\.\\s*+)(?![\\d\\.])", "\n$1");
+
+	    Matcher firstQuestionMatcher = Pattern.compile("^.*?(?=\\s*1\\.\\s*|\\s*\\[\\d+[~～]\\d+\\])", Pattern.DOTALL).matcher(tempText);
+	    String startText = tempText;
+	    String currentCommonPassage = ""; // [11~13]에 해당하는 긴 지문 텍스트
+    	String currentPassageScope = "";  // [11~13] 범위 텍스트
+	
+    	if (firstQuestionMatcher.find()) {
+            String preamble = firstQuestionMatcher.group(0).trim();
+            startText = tempText.substring(firstQuestionMatcher.end()).trim();
+
+            // Preamble(앞부분)에서 지문 범위와 내용을 추출
+            Matcher scopeMatcher = Pattern.compile("\\[(\\d+)\\s*[~～]\\s*(\\d+)\\]([\\s\\S]*)", Pattern.DOTALL).matcher(preamble);
+            if (scopeMatcher.find()) {
+                currentPassageScope = scopeMatcher.group(1) + "~" + scopeMatcher.group(2); // 예: 23~25
+                String passageContent = scopeMatcher.group(3).trim();
+
+                // 안내 문구 제거
+                passageContent = passageContent.replaceAll("다음 (글|자료)을 읽고 물음에 답하시오[\\.:]?", "").trim();
+                passageContent = passageContent.replaceAll("([가-힣\\s]+)을 읽고 물음에 답하시오[\\.:]?", "").trim();
+
+                currentCommonPassage = passageContent;
+//                System.out.println(">>> 초기 지문 블록 추출 (Scope: " + currentPassageScope + ")");
+            } else {
+                // 첫 문제 전에 지문 범위가 없지만 텍스트가 있는 경우, 공통 지문으로 간주
+                if (!preamble.isEmpty()) {
+                     currentCommonPassage = preamble;
+                }
+            }
+    	}
+    	
+	    // 문제 단위 분리
 	    String questionDelimiter = "(?=\\n\\s*\\d+\\.\\s*)"; // 문제 번호 패턴 (1. 2. 3.)
 	    // 공통 지문 관련 변수 초기화
- 		String currentCommonPassage = ""; // [11~13]에 해당하는 긴 지문 텍스트
- 		String currentPassageScope = "";   // [11~13] 범위 텍스트
-	    
-		String[] questionBlocks = startText.split(questionDelimiter);
-		
-		for(String rawBlock : questionBlocks) {
-			String trimmedBlock = rawBlock.trim();
-			
+	    String[] questionBlocks = startText.split(questionDelimiter);
+
+	    // 다음 지문 블록에 대한 정보를 임시로 저장할 변수
+	    String nextCommonPassage = "";
+	    String nextPassageScope = "";
+
+	    for(String rawBlock : questionBlocks) {
+	        String trimmedBlock = rawBlock.trim();
+
 	        if (trimmedBlock.isEmpty()) continue;
 	        
-	        // 블록 유형 확인 (지문 또는 문제)
+	        // **[2. 문제 블록 처리]**
+	        Matcher numMatcher = Pattern.compile("^(\\d+)\\.\\s*([\\s\\S]*)", Pattern.DOTALL).matcher(trimmedBlock);
 	        
-	        Matcher scopeMatcher = Pattern.compile("^\\[(\\d+)\\s*~\\s*(\\d+)\\]([\\s\\S]*)", Pattern.DOTALL).matcher(trimmedBlock);
-	        if(scopeMatcher.find()) {
-	        	// **[A] 지문 블록인 경우**
-	        	currentPassageScope = scopeMatcher.group(1) + "~" + scopeMatcher.group(2); // 예: 11~13
-	        	
-	        	// 지문 본문 텍스트 (범위 패턴 뒤의 모든 내용)
-	        	String passageContent = scopeMatcher.group(3).trim(); 
-	        	
-	        	// 안내 문구 (예: '다음 관을 읽고 물음에 답하시오.') 제거 정규식
-	            passageContent = passageContent.replaceFirst("^[\\s\\S]*?[\\?.:]\\s*", "").trim(); 
+	        if(numMatcher.find()) {
+	            if (!nextCommonPassage.isEmpty()) {
+	                currentCommonPassage = nextCommonPassage;
+	                currentPassageScope = nextPassageScope;
+	                nextCommonPassage = "";
+	                nextPassageScope = "";
+	            }
 	            
-	            currentCommonPassage = passageContent;
+	            int questionNum = Integer.parseInt(numMatcher.group(1));
+	            String contentPart = numMatcher.group(2).trim();
+
+	            // 3. 문제 블록의 꼬리에 다음 공통 지문이 붙어있는지 확인 (예: 10번 문제 끝에 [11~13]이 붙은 경우)
+	            // *해당 로직은 다음 문제의 지문을 찾아서 `nextCommonPassage`에 저장하는 역할만 함*
+	            Matcher scopeSeparatorMatcher = Pattern.compile("(\\s*\\[\\d+[~～]\\d+\\][\\s\\S]*)$", Pattern.DOTALL).matcher(contentPart);
+	            if(scopeSeparatorMatcher.find()) {
+	            	String passageBlock = scopeSeparatorMatcher.group(1).trim();
+	            	Matcher scopeOnlyMatcher = Pattern.compile("\\[(\\d+)\\s*[~～]\\s*(\\d+)\\]", Pattern.DOTALL).matcher(passageBlock);
+	            	if (scopeOnlyMatcher.find()) {
+
+	            		// **다음 문제에 사용될 변수에 저장**
+						nextPassageScope = scopeOnlyMatcher.group(1) + "~" + scopeOnlyMatcher.group(2);
+						int scopeEndIndex = scopeOnlyMatcher.end();
+						String contentAfterScope = passageBlock.substring(scopeEndIndex).trim();
+						
+                        // 안내 문구 제거 로직 단순화
+						String finalPassageContent = contentAfterScope.replaceAll("다음 (글|자료)을 읽고 물음에 답하시오[\\.:]?", "").trim();
+						finalPassageContent = finalPassageContent.replaceAll("([가-힣\\s]+)을 읽고 물음에 답하시오[\\.:]?", "").trim();
+						nextCommonPassage = finalPassageContent; // **다음 문제에 사용될 지문 저장**
+                        
+                        // 공통 지문이 바뀌었으므로 현재 지문 정보 초기화
+                        currentCommonPassage = "";
+                        currentPassageScope = "";
+	            	}
+	            	
+	            	// 4. 공통 지문 부분을 제거하여 contentPart를 정리 (현재 문제 내용만 남김)
+	            	contentPart = contentPart.substring(0, scopeSeparatorMatcher.start()).trim();
+
+//	            	System.out.println(">>> 지문 블록 (Scope: " + nextPassageScope + ") - 문제 " + questionNum + "번 끝에서 분리, 다음 문제에 적용 예정");
+	            }
 	            
-	            System.out.println(">>> 지문 블록 (Scope: " + currentPassageScope + ")");
-	        } else {
-	        	// **[B] 문제 블록인 경우**
-	        	Matcher numMatcher = Pattern.compile("^(\\d+)").matcher(trimmedBlock);
-	        	
-	        	if(numMatcher.find()) {
-	        		int questionNum = Integer.parseInt(numMatcher.group(1));
-		        	
-		        	// 문제 번호와 마침표를 제외한 나머지 텍스트 (문제 본문 + 선택지)
-		        	String contentBlock = trimmedBlock;
-		        	System.out.println(">>> 문제 블록 " + questionNum + "번");
-		            System.out.println("contentBlock: " + contentBlock);
-		            
-		            Map<String, Object> questionData = parseQuestionBlock(
-		            	questionNum, 
-		            	contentBlock,
-		            	currentCommonPassage, // 공통 지문 텍스트 전달
-		            	currentPassageScope   // 지문 범위 전달
-	            	);
-		            questions.add(questionData);
-	        	}
-	        	
+	            // --- 문제 파싱 로직 ---
+	            String contentBlock = contentPart; 
+
+//	            System.out.println(">>> 문제 블록 " + questionNum + "번");
+
+	            Map<String, Object> questionData = parseQuestionBlock(
+	                questionNum,
+	                contentBlock,
+	                currentCommonPassage, // 현재 저장된 공통 지문 텍스트 전달
+	                currentPassageScope	  // 현재 저장된 지문 범위 전달
+	            );
+	            questions.add(questionData);
+	            
+	            // 해당 문제가 지문의 마지막 문제였는지 확인하고, 맞다면 공통 지문 정보를 초기화
+                if (!currentPassageScope.isEmpty()) {
+                    try {
+                        String[] range = currentPassageScope.split("~");
+                        int end = Integer.parseInt(range[1]);
+                        
+                        if (questionNum == end) {
+//                            System.out.println(">>> 지문 범위 마지막 문제(" + end + "번) 완료. 공통 지문 초기화.");
+                            currentCommonPassage = "";
+                            currentPassageScope = "";
+                        }
+                    } catch (NumberFormatException e) {
+                        // 숫자로 파싱 실패 시, 무시하고 다음 문제로 진행
+                    }
+                }
 	        }
-	        
-		}
-		
-		return null;
+	    }
+
+	    // 파싱된 전체 문제 리스트를 반환
+	    return questions;
 	}
 	
 	// 시험 문제와 선택지 추출
 	private Map<String, Object> parseQuestionBlock(
-		int questionNum, 
-		String contentBlock,
-		String commonPassageText,
-		String passageScope) {
+	    int questionNum,
+	    String contentBlock,
+	    String commonPassageText,
+	    String passageScope
+	) {
 		Map<String, Object> questionData = new HashMap<>();
-		
-		// 1. 선택지 분리 정규식: ①, ②, ③, ④ 등 동그라미 숫자로 시작하는 패턴
-		String choiceDelimiter = "([①②③④⑤])";
-		
-		// 2. 시험 문제/지문 덩어리 추출 (선택지가 시작하는 위치를 찾아서 분리)
-		// 'contentBlock'의 텍스트 전체에서 [①]가 나오는 위치를 찾기만 함
-		Pattern choiceStartPattern = Pattern.compile("(?=[①②③④⑤])");
+
+	    // 1. 선택지 분리 정규식: ①, ②, ③, ④ 등 동그라미 숫자로 시작하는 패턴
+	    String choiceDelimiter = "([①②③④⑤])";
+
+	    // 2. 시험 문제/지문 덩어리 추출 (선택지가 시작하는 위치를 찾아서 분리)
+	    Pattern choiceStartPattern = Pattern.compile("(?=[①②③④⑤])");
 	    Matcher choiceMatcher = choiceStartPattern.matcher(contentBlock);
-	    
+
 	    String questionText; 		// 시험 문제(질문) 텍스트
-	    String questionPassageText; // 지문/보기 텍스트
+	    String questionPassageText; // 지문/보기 텍스트 (개별 지문)
 	    String preChoiceText; 		// 선택지(①, ②, ③...)가 시작되기 전까지의 모든 내용 (질문 + 지문)
-	    String choicesText;  		// 선택지
-	    
+	    String choicesText;			// 선택지
+
 	    if(choiceMatcher.find()) {
-	    	// 첫 번째 선택지 기호 직전까지를 '문제 본문'으로 간주
-	    	int startIndex = choiceMatcher.start(); // 첫 번째 선택지 기호(①)가 처음 나타나는 위치(인덱스)를 저장
-	    	preChoiceText = contentBlock.substring(0, startIndex).trim(); // (질문 + 지문) 추출
-	    	choicesText = contentBlock.substring(startIndex).trim(); // 첫 번째 선택지 기호부터 끝까지를 '선택지 덩어리'로 간주
+	        int startIndex = choiceMatcher.start();
+	        preChoiceText = contentBlock.substring(0, startIndex).trim();
+	        choicesText = contentBlock.substring(startIndex).trim();
 	    } else {
-	    	// 선택지 기호가 없는 경우 (선택지 덩어리는 비우고, 모든 텍스트를 지문/질문 텍스트로 간주)
-	    	preChoiceText  = contentBlock.trim();
+	        preChoiceText = contentBlock.trim();
 	        choicesText = "";
 	    }
-	    
+
 	    // 3. 'preChoiceText' (질문 + 지문) 덩어리를 분리
 	    int splitIndex = -1;
-	    // 물음표(?)가 있다면, 물음표 다음의 첫 번째 줄바꿈(\n)을 분리점으로 찾습니다.
 	    int questionMarkIndex = preChoiceText.indexOf('?');
 
 	    if (questionMarkIndex != -1) {
 	        splitIndex = preChoiceText.indexOf('\n', questionMarkIndex + 1);
 	    }
+	    
+	    // ?가 없는 경우를 대비하여 마침표(.) 또는 콜론(:) 다음 줄바꿈을 확인
+	    if (splitIndex == -1 && questionMarkIndex == -1) {
+	    	int lastPunctuationIndex = Math.max(preChoiceText.lastIndexOf('.'), preChoiceText.lastIndexOf(':'));
+	    	
+	    	if (lastPunctuationIndex != -1) {
+	    		// 마지막 구두점 이후의 첫 번째 줄바꿈을 찾음
+	    		int potentialSplitIndex = preChoiceText.indexOf('\n', lastPunctuationIndex + 1);
+	    		if (potentialSplitIndex != -1) {
+	    			splitIndex = potentialSplitIndex;
+	    		}
+	    	}
+	    	
+	    }
 
 	    if (splitIndex != -1) {
-	        // 분리점을 찾은 경우: [질문] + [지문/보기] 구조로 간주
 	        questionText = preChoiceText.substring(0, splitIndex).trim();
 	        questionPassageText = preChoiceText.substring(splitIndex).trim();
-
 	    } else {
-	        // 분리점을 찾지 못한 경우 (지문이 없는 순수 질문이거나 문장이 붙어 있는 경우)
 	        questionText = preChoiceText.trim();
 	        questionPassageText = "";
 	    }
-	    // questionText가 최종 결정된 후, 시작 부분의 문제 번호 잔재를 무조건 제거
+	    
 	    questionText = questionText.replaceFirst("^\\d+\\.\\s*", "").trim();
 	    
 	    // 4. 선택지 덩어리를 개별 선택지로 분리
-	    List<Map<String, String>> optionsList = new LinkedList<>();
+//	    List<Map<String, Object>> optionsList = new LinkedList<>();
+	    List<ExamChoiceDto> optionsList = new LinkedList<>();
 	    if(!choicesText.isEmpty()) {
-	    	// 선택지 분리
-	    	String[] options = choicesText.split(choiceDelimiter);
-	    	
-	    	for(String option: options) {
-	    		String trimmedOption = option.trim();
-	    		if(!trimmedOption.isEmpty()) {
-	    			// 라벨(①)과 나머지(선택지 텍스트)를 분리
-	    			String choiceLabel = trimmedOption.substring(0, 1);
-	    			String choiceText = trimmedOption.substring(1).trim();
-	    			
-	    			Map<String, String> choice = new HashMap<>();
-	    			choice.put("choiceLabel", choiceLabel);
-	    			choice.put("choiceText", choiceText);
-	    			optionsList.add(choice);
-	    		}
-	    	}
+	        String[] options = choicesText.split(choiceDelimiter);
+
+	        String[] labels = new String[]{"①", "②", "③", "④", "⑤"};
+	        int labelIndex = 0;
+
+	        for(String option: options) {
+	            String trimmedOption = option.trim();
+
+	            if(trimmedOption.isEmpty()) continue;
+	            if (labelIndex >= labels.length) break;
+
+	            String choiceLabel = labels[labelIndex];
+	            
+	            // 선택지 내용에서 불필요한 줄바꿈/구분자(예: //) 제거 및 공백 정규화
+	            String choiceText = trimmedOption
+	                                .replaceAll("(\r?\n)", " ") 
+	                                .replaceAll("//\\s*", "")   
+	                                .replaceAll("\\s{2,}", " ") 
+	                                .trim();
+	            /*
+	            Map<String, Object> choice = new HashMap<>();
+	            choice.put("choiceLabel", choiceLabel);
+	            choice.put("choiceText", choiceText);
+	            */
+	            optionsList.add(new ExamChoiceDto(choiceLabel, choiceText));
+
+	            labelIndex++;
+	        }
 	    }
-	    
+
 	    // 5. 추출 결과를 Map에 담아 반환
 	    questionData.put("questionNum", questionNum);
 	    questionData.put("questionText", questionText);
+
+	    // 개별 지문이 있으면 무조건 개별 지문을 사용하고 (문제 13번),
+	    // 개별 지문이 없을 때만 공통 지문을 사용 (문제 11, 12, 14, 15, 16번)
+	    String finalPassage;
+	    if (!questionPassageText.isEmpty()) {
+	        finalPassage = questionPassageText; // 개별 지문(보기) 우선
+	    } else {
+	        finalPassage = commonPassageText; // 개별 지문이 없으면 공통 지문 사용
+	    }
 	    
-	    // 지문이 있으면 그것을, 없으면 상위에서 받은 공통 지문을 사용
-	    String finalPassage = questionPassageText.isEmpty() ? commonPassageText : questionPassageText;
-	    
-	    questionData.put("questionPassage", finalPassage); // 지문/보기 텍스트
-	    questionData.put("passageScope", passageScope); // 공통 지문 범위
+	    questionData.put("questionPassage", finalPassage);
+	    questionData.put("passageScope", passageScope);
 	    questionData.put("options", optionsList);
-	    
+
 	    // 디버깅 출력
+	    /*
 	    System.out.println("--- 파싱 결과 ---");
 	    System.out.println("문제 번호: " + questionNum);
 	    System.out.println("질문 텍스트 (Question Text): " + questionText);
-	    System.out.println("지문/보기 텍스트 (Passage): " + questionPassageText);
+	    System.out.println("지문/보기 텍스트 (Passage): " + finalPassage); 
 	    System.out.println("선택지 수 (Options Count): " + optionsList.size());
 	    System.out.println("-----------------");
-	    
-		return null;
-//		return questionData;
+	     */
+
+	    return questionData;
 	}
 
 	// 시험 기본 정보 추출 (회차, 교시, 과목)
 	private String cleanAndExtractInfo(String fullText) {
+		// 오타 치환 먼저 수행
+		String cleanedText = replaceMistypedWords(fullText);
+		
 		// 1. 페이지 헤더 제거
-		String cleanedText = PAGE_HEADER_PATTERN.matcher(fullText).replaceAll("");
+		cleanedText = PAGE_HEADER_PATTERN.matcher(cleanedText).replaceAll("");
 		
 		// 2. 시험 기본 정보 추출 및 설정
 		Matcher infoMatcher = INFO_BLOCK_PATTERN.matcher(cleanedText);
@@ -233,13 +389,13 @@ public class GedExamParser implements IExamParser {
 			String subject = infoMatcher.group(5).replaceAll("\\s+", "").trim();
 			
 			// ExamInfo 객체 생성
-			ExamInfo examInfo = new ExamInfo(round, subject, sessionNo);
+			this.examInfo = new ExamInfoDto(round, subject, sessionNo);
 			
 			// 추출된 기본 정보 블록을 텍스트에서 제거
 			cleanedText = infoMatcher.replaceAll("");
 		} else {
-			System.err.println("Warning: Could not extract GED Exam Info block. Setting to null.");
-			ExamInfo examInfo = new ExamInfo(null, null, null);
+			System.err.println("Warning: GED 시험 정보를 추출하지 못해 null로 설정");
+			this.examInfo = new ExamInfoDto(null, null, null);
 		}
 		
 		// 3. 과도한 공백 및 줄바꿈 정리
@@ -247,6 +403,16 @@ public class GedExamParser implements IExamParser {
 		cleanedText = cleanedText.replaceAll("\\s{2,}", " ");
 		
 		return cleanedText.trim();
+	}
+	
+	private String replaceMistypedWords(String text) {
+	    String correctedText = text;
+	    // Map에 정의된 모든 키-값 쌍에 대해 반복하여 치환
+	    for (Map.Entry<String, String> entry : CORRECTION_MAP.entrySet()) {
+	        String regex = Pattern.quote(entry.getKey());
+	        correctedText = correctedText.replaceAll(regex, entry.getValue());
+	    }
+	    return correctedText;
 	}
 	
 }

--- a/src/main/java/com/my/ex/parser/IExamParser.java
+++ b/src/main/java/com/my/ex/parser/IExamParser.java
@@ -3,14 +3,16 @@ package com.my.ex.parser;
 import java.util.List;
 import java.util.Map;
 
+import com.my.ex.dto.ExamInfoDto;
+
 public interface IExamParser {
-	/*
+	/**
 	 * 파싱된 시험 기본 정보를 반환
 	 * @return ExamInfo 객체
 	 * */
-	ExamInfo getExamInfo();
+	ExamInfoDto getExamInfo();
 	
-	/*
+	/**
 	 * 전체 텍스트를 파싱하여 문제 데이터 리스트를 반환
 	 * @param fullText 전체 시험지 텍스트
 	 * @return 파싱된 문제 및 선택지 데이터 맵 리스트 

--- a/src/main/java/com/my/ex/service/ExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/ExamSelectionService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.my.ex.dao.ExamSelectionDao;
+import com.my.ex.dto.ExamChoiceDto;
 import com.my.ex.dto.ExamInfoDto;
 import com.my.ex.dto.ExamTypeDto;
 
@@ -34,6 +35,37 @@ public class ExamSelectionService implements IExamSelectionService {
 		map.put("examRound", examRound);
 		
 		return dao.getExamSubjects(map);
+	}
+
+	@Override
+	public boolean saveParsedExamData(ExamInfoDto examInfo, List<Map<String, Object>> questions) {
+		// 중복 시험 정보 확인
+		if(dao.checkExistingExamInfo(examInfo) > 0) return false;
+		
+		// 시험 정보 저장
+		dao.saveParsedExamInfo(examInfo); // 시험 정보 저장 후 examId 받아옴
+		Integer examId = (Integer)examInfo.getExamId(); // DB 삽입 후 주입된 examId
+		if(examId == null || examId <= 0) throw new RuntimeException();
+		
+		// 시험 문제 저장
+		for(Map<String, Object> question : questions) {
+			question.put("examId", examId);
+			dao.saveParsedQuestionInfo(question); // 문제 저장 후 questionId 받아옴
+			Integer questionId = (Integer)question.get("questionId"); // DB 삽입 후 주입된 questionId
+			if(questionId == null || questionId <= 0) throw new RuntimeException();
+			
+			// 시험 선택지 저장
+			@SuppressWarnings("unchecked")
+			List<ExamChoiceDto> options = (List<ExamChoiceDto>) question.get("options");
+			for(ExamChoiceDto choiceDto : options) {
+				choiceDto.setQuestionId(questionId);
+				
+				int insertResult = dao.saveParsedChoiceInfo(choiceDto);
+				if(insertResult <= 0) throw new RuntimeException();
+			}
+		}
+		
+		return true;
 	}
 
 }

--- a/src/main/java/com/my/ex/service/IExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/IExamSelectionService.java
@@ -1,6 +1,7 @@
 package com.my.ex.service;
 
 import java.util.List;
+import java.util.Map;
 
 import com.my.ex.dto.ExamInfoDto;
 import com.my.ex.dto.ExamTypeDto;
@@ -9,4 +10,5 @@ public interface IExamSelectionService {
 	List<ExamTypeDto> getExamTypes();
 	List<String> getExamRounds(String examTypeCode);
 	List<String> getExamSubjects(String examTypeCode, String examRound);
+	boolean saveParsedExamData(ExamInfoDto examInfo, List<Map<String, Object>> questions);
 }

--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -33,4 +33,84 @@
 		   AND exam_round = #{examRound}
 		 ORDER BY exam_subject
 	</select>
+	
+	<!-- 중복 시험 여부 확인 -->
+	<select id="checkExistingExamInfo" parameterType="ExamInfoDto" resultType="Integer">
+		SELECT COUNT(*)
+		  FROM exam_info
+		 WHERE exam_type_id = #{examTypeId}
+		   AND exam_round = #{examRound}
+		   AND exam_subject = #{examSubject}
+	</select>
+	
+	<!-- 시험 정보 저장 -->
+	<insert id="saveParsedExamInfo" parameterType="ExamInfoDto">
+		<selectKey resultType="int" keyProperty="examId" order="BEFORE" >
+			SELECT seq_exam_info.nextval FROM dual
+		</selectKey>
+		INSERT INTO exam_info
+			(
+			exam_id,
+			exam_type_id,
+			exam_round,
+			exam_subject,
+			sessionNo
+			)
+		 VALUES
+		 	(
+		 	#{examId},
+		 	#{examTypeId},
+		 	#{examRound},
+		 	#{examSubject},
+		 	#{sessionNo}
+		 	)
+	</insert>
+	
+	<!-- 시험 문제 저장 -->
+	<insert id="saveParsedQuestionInfo" parameterType="java.util.HashMap">
+		<selectKey keyProperty="questionId" resultType="int" order="BEFORE">
+			SELECT seq_exam_question.nextval FROM dual
+		</selectKey>
+		INSERT INTO exam_question
+			(
+			question_id,
+			exam_id,
+			question_num,
+			question_text,
+			question_image,
+			question_passage,
+			passage_scope
+			)
+		VALUES
+			(
+			#{questionId},
+			#{examId},
+			#{questionNum},
+			#{questionText},
+			null,
+			#{questionPassage},
+			#{passageScope}
+			)
+	</insert>
+	
+	<!-- 시험 선택지 저장 -->
+	<insert id="saveParsedChoiceInfo" parameterType="ExamChoiceDto">
+		INSERT INTO exam_choice
+			(
+			choice_id,
+			question_id,
+			choice_label,
+			choice_text,
+			choice_image
+			)
+		VALUES
+			(
+			seq_exam_choice.nextval,
+			#{questionId},
+			#{choiceLabel},
+			#{choiceText},
+			#{choiceImage}
+			)
+	</insert>
+	
 </mapper>

--- a/src/main/webapp/resources/js/examInfo.js
+++ b/src/main/webapp/resources/js/examInfo.js
@@ -93,12 +93,12 @@ document.addEventListener('DOMContentLoaded', () => {
     ================================================== */
     nextButton.addEventListener('click', (e) => {
         e.preventDefault()
-        const obj = {
+        const params = new URLSearchParams({
             examType: examTypeSelect.value,
             examRound: examRoundSelect.value,
             examSubject: examSubjectSelect.value
-        }
+        }).toString()
 
-        console.log(obj)
+        window.location.href = `/exam/showExamPage?${params}`
     })
 })

--- a/src/main/webapp/resources/js/package-lock.json
+++ b/src/main/webapp/resources/js/package-lock.json
@@ -10,8 +10,21 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",
-        "pdf-parse": "^1.1.1"
+        "pdf-parse": "^1.1.1",
+        "pdf2pic": "^3.2.0"
       }
+    },
+    "node_modules/array-parallel": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
+      "integrity": "sha512-TDPTwSWW5E4oiFiKmz6RGJ/a80Y91GuLgUYuLd49+XBS75tYo8PNgaT2K/OxuQYqkoI852MDGBorg9OcUSTQ8w==",
+      "license": "MIT"
+    },
+    "node_modules/array-series": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
+      "integrity": "sha512-L0XlBwfx9QetHOsbLDrE/vh2t018w9462HM3iaFfxRiK83aJjAt/Ja3NMkOW7FICwWTlQBa3ZbL5FKhuQWkDrg==",
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -53,6 +66,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -214,6 +241,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/gm": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.25.1.tgz",
+      "integrity": "sha512-jgcs2vKir9hFogGhXIfs0ODhJTfIrbECCehg38tqFgHm8zqXx7kAJyCYAFK4jTjx71AxrkFtkJBawbAxYUPX9A==",
+      "deprecated": "The gm module has been sunset. Please migrate to an alternative. https://github.com/aheckmann/gm?tab=readme-ov-file#2025-02-24-this-project-is-not-maintained",
+      "license": "MIT",
+      "dependencies": {
+        "array-parallel": "~0.1.3",
+        "array-series": "~0.1.5",
+        "cross-spawn": "^7.0.5",
+        "debug": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -265,6 +308,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -307,6 +356,15 @@
       "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
       "license": "MIT"
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pdf-parse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
@@ -320,11 +378,63 @@
         "node": ">=6.8.1"
       }
     },
+    "node_modules/pdf2pic": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pdf2pic/-/pdf2pic-3.2.0.tgz",
+      "integrity": "sha512-p0bp+Mp4iJy2hqSCLvJ521rDaZkzBvDFT9O9Y0BUID3I04/eDaebAFM5t8hoWeo2BCf42cDijLCGJWTOtkJVpA==",
+      "license": "MIT",
+      "dependencies": {
+        "gm": "^1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://www.paypal.me/yakovmeister"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     }
   }
 }

--- a/src/main/webapp/resources/js/package.json
+++ b/src/main/webapp/resources/js/package.json
@@ -11,6 +11,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.12.2",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "pdf2pic": "^3.2.0"
   }
 }

--- a/src/main/webapp/resources/js/pdf-reader.js
+++ b/src/main/webapp/resources/js/pdf-reader.js
@@ -1,6 +1,5 @@
 const axios = require("axios");
-const pdf = require("pdf-parse");
-// const fs = require("fs");
+const pdf = require("pdf-parse"); // pdf-parse 라이브러리 불러옴
 
 const pdfUrl = "https://www.gumsi.or.kr/ged/cmmn/brd/fileDownload.do?flId=1128&flSn=1";
 // const pdfUrl1 = "https://www.kice.re.kr/boardCnts/fileDown.do"
@@ -26,14 +25,14 @@ function getPdfTextWithAxios(url) {
     })
     .then((response) => {
         const buffer = Buffer.from(response.data);
-        return pdf(buffer);
+        return pdf(buffer); // 다운로드한 pdf 텍스트 추출
     })
     .then((data) => {
         console.log("✅ PDF 텍스트 추출 성공!");
         console.log("----------------------------------");
         console.log(data.text);
 
-      // Java 서버에 POST 요청으로 텍스트 전송
+        // Java 서버에 POST 요청으로 텍스트 전송
         return axios.post(javaApiUrl, { text: data.text });
     })
     .then((response) => {


### PR DESCRIPTION
## 📌 변경 사항
- 크롤링한 PDF 문제지 데이터를 파싱하여 문제, 선택지, 정답 정보를 DB에 삽입하는 로직 구현
- 기본적인 모듈화 및 과목별 확장성 고려한 구조 설계

## 🛠️ 수정한 이유
- 문제지 데이터를 수동으로 입력하는 비효율적인 과정을 자동화하여 작업 효율성을 높이고, 데이터 정확성을 개선하기 위함
- 앞으로 방대한 양의 문제지를 효과적으로 관리하고, 다양한 문제 유형에 대응할 수 있는 기반 마련을 위함

## 🔍 주요 변경 파일
- ExamSelectionController.java
- ExamSelectionService.java
- ExamSelectionDao.java
- ExamAnswerDto.java // 시험 정답
- ExamChoiceDto.java // 시험 선택지 
- ExamInfoDto.java // 시험 기본 정보
- ExamQuestionDto.java // 시험 문제
- ExamSelectionmapper.xml

- examInfo.js
- pdf-reader.js // node.js

## 📌 향후 계획
- 데이터가 방대하여 PDF를 이미지로 변환하여 URL만 삽입하는 방식을 고려 중이나, 이 경우 오답노트 등 추가 기능 구현에 제약이 있어 우선은 텍스트 데이터를 DB에 삽입하는 방식으로 진행
- 추후 데이터 용량 및 파싱 정확도 문제에 따른 대응 방안 고민 필요
- PDF 업로드 시 자동 파싱 기능 구현 예정

## ✅ 테스트 내용
- [x] PDF 문제 데이터가 정상적으로 파싱되고 DB에 삽입되는지 확인
- [x] 추출된 텍스트 내 오타가 적절히 치환/보정되었는지 확인
- [x] 시험 정보, 시험 문제, 선택지 각 테이블에 데이터가 올바르게 저장되었는지 확인

## 🔗 관련 이슈
closes #11 
