### PR TITLE
[FEAT] 시험 응시 UI 구현

### DIFF
--- a/src/main/java/com/my/ex/controller/ExamSelectionController.java
+++ b/src/main/java/com/my/ex/controller/ExamSelectionController.java
@@ -1,9 +1,14 @@
 package com.my.ex.controller;
 
+import java.io.File;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,10 +18,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.my.ex.config.EnvironmentConfig;
+import com.my.ex.dto.ExamChoiceDto;
+import com.my.ex.dto.ExamCommonpassageDto;
 import com.my.ex.dto.ExamInfoDto;
 import com.my.ex.dto.ExamInfoGroup;
+import com.my.ex.dto.ExamPageDto;
+import com.my.ex.dto.ExamQuestionDto;
 import com.my.ex.dto.ExamTypeDto;
-import com.my.ex.parser.ExamInfo;
 import com.my.ex.parser.GedExamParser;
 import com.my.ex.service.ExamSelectionService;
 
@@ -26,6 +35,9 @@ public class ExamSelectionController {
 	
 	@Autowired
 	private ExamSelectionService service;
+	
+	@Autowired
+	private EnvironmentConfig config;
 	
 	@GetMapping("/main")
 	public String mainPage(Model model) {
@@ -48,8 +60,9 @@ public class ExamSelectionController {
 	@GetMapping("/getExamSubjects")
 	@ResponseBody
 	public ExamInfoGroup getExamSubjects(
-			@RequestParam String examTypeCode,
-			@RequestParam String examRound) {
+		@RequestParam String examTypeCode,
+		@RequestParam String examRound) 
+	{
 		List<String> examSubjects = service.getExamSubjects(examTypeCode, examRound);
 		
 		ExamInfoGroup group = new ExamInfoGroup();
@@ -81,12 +94,67 @@ public class ExamSelectionController {
 		}
 		
 	}
-	
+
+	/**
+	 * 시험 조건에 해당하는 시험 정보를 조회
+	 * @param examType 시험 종류 (예: "middle-geomjeong")
+	 * @param examRound 시험 회차 정보 (예: "2025년도 제1회")
+	 * @param examSubject 과목명 (예: "국어")
+	 * @return
+	 */
 	@GetMapping("/showExamPage")
-	public String showExamPage(ExamInfo params) {
-		System.out.println(params);
+//	@ResponseBody
+	public String showExamPage (
+//	public Map<String, Object> showExamPage (
+		@RequestParam String examType,
+		@RequestParam String examRound,
+		@RequestParam String examSubject,
+		Model model) 
+	{
+		
+		String examTypename = service.getExamtypename(examType);
+		List<ExamQuestionDto> questions = service.getExamQuestions(examType, examRound, examSubject);
+		List<ExamChoiceDto> choices = service.getExamChoices();
+		Set<ExamCommonpassageDto> distinctPassageDto = service.getCommonPassageInfo(examType, examRound, examSubject); // 공통지문 시작번호 추출
+		ExamPageDto response = new ExamPageDto(questions, examTypename, examRound, examSubject, choices, distinctPassageDto);
+		model.addAttribute("examPageDto", response);
 		
 		return "/exam/exam_page";
+			
+		
+//		Map<String, Object> map = new HashMap<>();
+//		String examTypename = service.getExamtypename(examType);
+//		List<ExamQuestionDto> questions = service.getExamQuestions(examType, examRound, examSubject);
+//		List<ExamChoiceDto> choices = service.getExamChoices();
+//		Set<ExamCommonpassageDto> distinctPassageDto = service.getCommonPassageInfo(examType, examRound, examSubject); // 공통지문 시작번호 추출
+//		ExamPageDto response = new ExamPageDto(questions, examTypename, examRound, examSubject, choices, distinctPassageDto);
+//		map.put("examPageDto", response);
+//	
+//		return map;
+		
+	}
+	
+	@GetMapping("/getExamImagePath")
+	@ResponseBody
+	public Resource getExamImagePath(
+		@RequestParam String examType,
+		@RequestParam String examRound,
+		@RequestParam String examSubject,
+		@RequestParam String filename)
+	{
+		String path = 
+				config.getImageUploadPath() +
+				examType + "\\" +
+				examRound + "\\" +
+				examSubject + "\\" +
+				filename;
+		// C:\server_program\project\testmate\images\2025년도 제1회\국어
+		File file = new File(path);
+		if (file.exists()) {
+			return new FileSystemResource(file); // file자체를 보내는 것은 X, HTTP 본문 응답으로 자동 변환해주는 API(FileSystemResource())를 이용해서 보내야 함
+		} else {
+			throw new RuntimeException("File not found: " + file.getAbsolutePath());
+		}
 	}
 	
 }

--- a/src/main/java/com/my/ex/dao/ExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/ExamSelectionDao.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import com.my.ex.dto.ExamChoiceDto;
 import com.my.ex.dto.ExamInfoDto;
+import com.my.ex.dto.ExamQuestionDto;
 import com.my.ex.dto.ExamTypeDto;
 
 @Repository
@@ -52,6 +53,26 @@ public class ExamSelectionDao implements IExamSelectionDao {
 	@Override
 	public int saveParsedChoiceInfo(ExamChoiceDto option) {
 		return session.insert(NAMESPACE + "saveParsedChoiceInfo", option);
+	}
+
+	@Override
+	public String getExamtypename(String examType) {
+		return session.selectOne(NAMESPACE + "getExamtypename", examType);
+	}
+	
+	@Override
+	public List<ExamQuestionDto> getExamQuestions(Map<String, Object> map) {
+		return session.selectList(NAMESPACE + "getExamQuestions", map);
+	}
+
+	@Override
+	public List<ExamChoiceDto> getExamChoices() {
+		return session.selectList(NAMESPACE + "getExamChoices");
+	}
+
+	@Override
+	public List<ExamQuestionDto> getCommonPassageInfo(Map<String, Object> map) {
+		return session.selectList(NAMESPACE + "getCommonPassageInfo", map);
 	}
 
 }

--- a/src/main/java/com/my/ex/dao/IExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/IExamSelectionDao.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import com.my.ex.dto.ExamChoiceDto;
 import com.my.ex.dto.ExamInfoDto;
+import com.my.ex.dto.ExamQuestionDto;
 import com.my.ex.dto.ExamTypeDto;
 
 public interface IExamSelectionDao {
@@ -15,4 +16,8 @@ public interface IExamSelectionDao {
 	void saveParsedExamInfo(ExamInfoDto examInfo);
 	void saveParsedQuestionInfo(Map<String, Object> question);
 	int saveParsedChoiceInfo(ExamChoiceDto option);
+	String getExamtypename(String examType);
+	List<ExamQuestionDto> getExamQuestions(Map<String, Object> map);
+	List<ExamChoiceDto> getExamChoices();
+	List<ExamQuestionDto> getCommonPassageInfo(Map<String, Object> map);
 }

--- a/src/main/java/com/my/ex/dto/ExamCommonpassageDto.java
+++ b/src/main/java/com/my/ex/dto/ExamCommonpassageDto.java
@@ -1,0 +1,11 @@
+package com.my.ex.dto;
+
+import lombok.Data;
+
+// 공통지문 관리 dto
+@Data
+public class ExamCommonpassageDto {
+	private int commonPassageStartNum;
+	private int commonPassageEndNum;
+	private String commonPassageText;
+}

--- a/src/main/java/com/my/ex/dto/ExamPageDto.java
+++ b/src/main/java/com/my/ex/dto/ExamPageDto.java
@@ -1,0 +1,18 @@
+package com.my.ex.dto;
+
+import java.util.List;
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ExamPageDto {
+	private List<ExamQuestionDto> examQuestions;
+	private String examType;
+	private String examRound;
+	private String examSubject;
+	private List<ExamChoiceDto> examChoices;
+	private Set<ExamCommonpassageDto> distinctPassageDto;
+}

--- a/src/main/java/com/my/ex/dto/ExamQuestionDto.java
+++ b/src/main/java/com/my/ex/dto/ExamQuestionDto.java
@@ -5,11 +5,13 @@ import lombok.Data;
 @Data
 public class ExamQuestionDto {
 	private int questionId;
-	private int examId; 			// exam_info fk
-	private String sessionNo; 		// 교시
-	private int questionNum; 		// 문제 번호
-	private String questionText; 	// 문제 내용
-	private String questionImage; 	// 문제 이미지 URL
-	private String questionPassage; // 문제 지문 텍스트
-	private String passageScope; 	// 지문 적용 범위 (예: [11~13])
+	private int examId; 				// exam_info fk
+	private String sessionNo; 			// 교시
+	private int questionNum; 			// 문제 번호
+	private String questionText; 		// 문제 내용
+	private String questionImage; 		// 문제 이미지 URL
+//	private String questionPassage; 	// 문제 지문 텍스트
+	private String individualPassage; 	// 단독 지문
+	private String commonPassage;		// 공통 지문
+	private String passageScope; 		// 지문 적용 범위 (예: [11~13])
 }

--- a/src/main/java/com/my/ex/parser/GedExamParser.java
+++ b/src/main/java/com/my/ex/parser/GedExamParser.java
@@ -194,8 +194,8 @@ public class GedExamParser implements IExamParser {
 						nextCommonPassage = finalPassageContent; // **다음 문제에 사용될 지문 저장**
                         
                         // 공통 지문이 바뀌었으므로 현재 지문 정보 초기화
-                        currentCommonPassage = "";
-                        currentPassageScope = "";
+//                        currentCommonPassage = "";
+//                        currentPassageScope = "";
 	            	}
 	            	
 	            	// 4. 공통 지문 부분을 제거하여 contentPart를 정리 (현재 문제 내용만 남김)
@@ -218,6 +218,7 @@ public class GedExamParser implements IExamParser {
 	            questions.add(questionData);
 	            
 	            // 해당 문제가 지문의 마지막 문제였는지 확인하고, 맞다면 공통 지문 정보를 초기화
+	            /*
                 if (!currentPassageScope.isEmpty()) {
                     try {
                         String[] range = currentPassageScope.split("~");
@@ -232,6 +233,7 @@ public class GedExamParser implements IExamParser {
                         // 숫자로 파싱 실패 시, 무시하고 다음 문제로 진행
                     }
                 }
+                */
 	        }
 	    }
 
@@ -341,16 +343,24 @@ public class GedExamParser implements IExamParser {
 
 	    // 개별 지문이 있으면 무조건 개별 지문을 사용하고 (문제 13번),
 	    // 개별 지문이 없을 때만 공통 지문을 사용 (문제 11, 12, 14, 15, 16번)
-	    String finalPassage;
-	    if (!questionPassageText.isEmpty()) {
-	        finalPassage = questionPassageText; // 개별 지문(보기) 우선
-	    } else {
-	        finalPassage = commonPassageText; // 개별 지문이 없으면 공통 지문 사용
-	    }
 	    
-	    questionData.put("questionPassage", finalPassage);
+	    // 개별지문, 공통지문 분리 수정
+//	    String finalPassage;
+//	    
+//	    if (!questionPassageText.isEmpty()) {
+//	        finalPassage = questionPassageText; // 개별 지문(보기) 우선
+//	    } else if (!commonPassageText.isEmpty()) { // 추가: 공통 지문이 있을 때만 사용
+//	        finalPassage = commonPassageText; 
+//	    } else {
+//	        finalPassage = "";
+//	    }
+	    
+	    questionData.put("individualPassage", questionPassageText);
+	    questionData.put("commonPassage", commonPassageText);
+//	    questionData.put("questionPassage", finalPassage);
 	    questionData.put("passageScope", passageScope);
 	    questionData.put("options", optionsList);
+	    
 
 	    // 디버깅 출력
 	    /*

--- a/src/main/java/com/my/ex/service/ExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/ExamSelectionService.java
@@ -1,15 +1,22 @@
 package com.my.ex.service;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.my.ex.config.EnvironmentConfig;
+import com.my.ex.controller.ExamSelectionController;
 import com.my.ex.dao.ExamSelectionDao;
 import com.my.ex.dto.ExamChoiceDto;
+import com.my.ex.dto.ExamCommonpassageDto;
 import com.my.ex.dto.ExamInfoDto;
+import com.my.ex.dto.ExamQuestionDto;
 import com.my.ex.dto.ExamTypeDto;
 
 @Service
@@ -66,6 +73,54 @@ public class ExamSelectionService implements IExamSelectionService {
 		}
 		
 		return true;
+	}
+
+	@Override
+	public String getExamtypename(String examType) {
+		return dao.getExamtypename(examType);
+	}
+	
+	@Override
+	public List<ExamQuestionDto> getExamQuestions(String examType, String examRound, String examSubject) {
+		Map<String, Object> map = new HashMap<>();
+		map.put("examType", examType);
+		map.put("examRound", examRound);
+		map.put("examSubject", examSubject);
+		
+		return dao.getExamQuestions(map);
+	}
+
+	@Override
+	public List<ExamChoiceDto> getExamChoices() {
+		return dao.getExamChoices();
+	}
+	
+	@Override
+	public Set<ExamCommonpassageDto> getCommonPassageInfo(String examType, String examRound, String examSubject) {
+		Map<String, Object> map = new HashMap<>();
+		map.put("examType", examType);
+		map.put("examRound", examRound);
+		map.put("examSubject", examSubject);
+		List<ExamQuestionDto> questionDto = dao.getCommonPassageInfo(map);
+		
+		ExamCommonpassageDto commonpassageDto; 
+//		List<ExamCommonpassageDto> distinctPassageList = new ArrayList<>();
+		Set<ExamCommonpassageDto> distinctPassageSet = new HashSet<>();
+		
+		for(ExamQuestionDto dto: questionDto) {
+			commonpassageDto = new ExamCommonpassageDto();
+			String scope = dto.getPassageScope(); // 11~13
+			
+			commonpassageDto.setCommonPassageStartNum(Integer.parseInt(scope.split("~")[0])); // 11
+			commonpassageDto.setCommonPassageEndNum(Integer.parseInt(scope.split("~")[1])); // 13
+			commonpassageDto.setCommonPassageText(dto.getCommonPassage()); // 공통 지문
+			distinctPassageSet.add(commonpassageDto);
+//			distinctPassageList.add(commonpassageDto);
+		}
+//		System.out.println("Set size: " + distinctPassageSet.size()); // Set size: 5
+//		System.out.println("List size: " + distinctPassageList.size()); // List size: 15
+		
+		return distinctPassageSet;
 	}
 
 }

--- a/src/main/java/com/my/ex/service/IExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/IExamSelectionService.java
@@ -2,8 +2,12 @@ package com.my.ex.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import com.my.ex.dto.ExamChoiceDto;
+import com.my.ex.dto.ExamCommonpassageDto;
 import com.my.ex.dto.ExamInfoDto;
+import com.my.ex.dto.ExamQuestionDto;
 import com.my.ex.dto.ExamTypeDto;
 
 public interface IExamSelectionService {
@@ -11,4 +15,8 @@ public interface IExamSelectionService {
 	List<String> getExamRounds(String examTypeCode);
 	List<String> getExamSubjects(String examTypeCode, String examRound);
 	boolean saveParsedExamData(ExamInfoDto examInfo, List<Map<String, Object>> questions);
+	String getExamtypename(String examType);
+	List<ExamQuestionDto> getExamQuestions(String examType, String examRound, String examSubject);
+	List<ExamChoiceDto> getExamChoices();
+	Set<ExamCommonpassageDto> getCommonPassageInfo(String examType, String examRound, String examSubject);
 }

--- a/src/main/java/com/my/ex/service/IUserService.java
+++ b/src/main/java/com/my/ex/service/IUserService.java
@@ -1,7 +1,5 @@
 package com.my.ex.service;
 
-import org.springframework.web.bind.annotation.RequestParam;
-
 import com.my.ex.dto.UserDto;
 
 public interface IUserService {

--- a/src/main/java/com/my/ex/service/UserService.java
+++ b/src/main/java/com/my/ex/service/UserService.java
@@ -26,5 +26,5 @@ public class UserService implements IUserService {
 	public boolean checkIdDuplicate(String checkId) {
 		return dao.checkIdDuplicate(checkId) > 0;
 	}
-	
+
 }

--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -78,7 +78,8 @@
 			question_num,
 			question_text,
 			question_image,
-			question_passage,
+			individualPassage,
+			commonPassage,
 			passage_scope
 			)
 		VALUES
@@ -88,7 +89,8 @@
 			#{questionNum},
 			#{questionText},
 			null,
-			#{questionPassage},
+			#{individualPassage},
+			#{commonPassage},
 			#{passageScope}
 			)
 	</insert>
@@ -112,5 +114,53 @@
 			#{choiceImage}
 			)
 	</insert>
+	
+	<!-- 시험 종류 가져오기 -->
+	<select id="getExamtypename" resultType="String">
+		SELECT exam_type_name
+		  FROM exam_type
+		 WHERE exam_type_code = #{examType}
+	</select>
+	
+	<!-- 시험 문제 가져오기 -->
+	<select id="getExamQuestions" parameterType="java.util.HashMap" resultType="ExamQuestionDto">
+		SELECT Q.question_id,
+			   Q.question_num,
+		       Q.question_text,
+		       Q.question_image,
+		       Q.individualPassage,
+		       Q.commonPassage,
+		       Q.passage_scope
+		  FROM exam_question Q
+		  JOIN exam_info I on Q.exam_id = I.exam_id
+		  JOIN exam_type T on I.exam_type_id = T.exam_type_id
+		 WHERE T.exam_type_code = #{examType}
+		   AND I.exam_round = #{examRound}
+		   AND I.exam_subject = #{examSubject}
+		 ORDER BY Q.question_num asc
+	</select>
+	
+	<!-- 선택지 가져오기 -->
+	<select id="getExamChoices" resultType="ExamChoiceDto">
+		SELECT question_id,
+			   choice_id,
+		       choice_label,
+		       choice_text,
+		       choice_image
+		  FROM exam_choice
+		 ORDER BY question_id ASC, choice_label ASC
+	</select>
+	
+	<!-- 공통 지문 시작번호 추출 -->
+	<select id="getCommonPassageInfo" parameterType="java.util.HashMap" resultType="ExamQuestionDto">
+		SELECT Q.passage_scope, Q.commonpassage
+		  FROM exam_question Q
+		  JOIN exam_info I on Q.exam_id = I.exam_id
+		  JOIN exam_type T on I.exam_type_id = T.exam_type_id
+		 WHERE T.exam_type_code = #{examType}
+		   AND I.exam_round = #{examRound}
+		   AND I.exam_subject = #{examSubject}
+		   AND Q.passage_scope IS NOT NULL
+	</select>
 	
 </mapper>

--- a/src/main/webapp/WEB-INF/views/exam/exam_page.jsp
+++ b/src/main/webapp/WEB-INF/views/exam/exam_page.jsp
@@ -1,0 +1,107 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Insert title here</title>
+<link href="<c:url value="/resources/css/exam_page.css"/>" rel="stylesheet">
+<!-- axios -->
+<script type="module" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+</head>
+<body>
+	<div class="exam-container">
+        
+        <header class="exam-header">
+            <h1 class="exam-title">
+            	<a href="/">${examPageDto.examType} (${examPageDto.examRound}) ${examPageDto.examSubject}</a>
+           	</h1>
+            <div class="timer-box">
+                <span id="timer">00:00</span>
+            </div>
+            <button type="submit" form="examForm" class="submit-button">시험 종료 및 제출</button>
+        </header>
+
+        <form id="examForm" action="/exam/submitExam" method="post">
+            <div class="exam-content-wrapper no-omr">
+                <div class="question-area full-width">
+
+                    <!-- 문제들 -->
+                    <c:forEach items="${examPageDto.examQuestions}" var="questionDto" varStatus="status" >
+                        <div class="question-item">
+                            <!-- 공통 지문 -->
+                            <c:forEach items="${examPageDto.distinctPassageDto}" var="commonPassageDto">
+                            	<c:if test="${questionDto.questionNum == commonPassageDto.commonPassageStartNum}">
+                            		<div class="common-text-box">
+                                        <p class="text-range">
+                                            [${commonPassageDto.commonPassageStartNum}~${commonPassageDto.commonPassageEndNum}] 다음 글을 읽고 물음에 답하시오.
+                                        </p>
+                                        <div class="text-content">
+                                            ${commonPassageDto.commonPassageText}
+                                        </div>
+                                    </div>
+                            	</c:if>
+                            </c:forEach>
+                            
+                            <!-- 문제 번호 및 텍스트 -->
+                            <p class="question-number" id="qnum_${questionDto.questionNum}">${questionDto.questionNum}. ${questionDto.questionText}</p>
+
+                            <!-- 단독 지문 -->
+                            <c:choose>
+                            	<c:when test="${not empty questionDto.questionImage}">
+                            		<div class="question-media-box">
+                                        <img src=
+                                            "/exam/getExamImagePath?examType=${examPageDto.examType}&examRound=${examPageDto.examRound}&examSubject=${examPageDto.examSubject}&filename=${questionDto.questionImage}" 
+											alt="문제 이미지" 
+											class="question-image"
+										>
+                                	</div>
+                            	</c:when>
+                            	<c:when test="${not empty questionDto.individualPassage}">
+									<div class="question-media-box">
+								        <div class="text-content single-passage">${questionDto.individualPassage}</div>
+								    </div>                            	
+                            	</c:when>
+                            </c:choose>
+                    		<div class="options-group">
+                    		
+                    			<!-- 선택지들 -->
+                    			<c:forEach items="${examPageDto.examChoices}" var="choiceDto">
+                    				<c:choose>
+                    					<c:when test="${choiceDto.questionId == questionDto.questionId}">
+                    						<label class="option-label full-click">
+                    						
+                    							<!-- 선택지 번호 -->
+                                                <input type="radio" name="question_${questionDto.questionId}" value="${choiceDto.choiceId}">
+                                                <span class="omr-bubble">${choiceDto.choiceLabel}</span>
+                                                
+                                                <!-- 선택지 내용 -->
+                                                <c:if test="${not empty choiceDto.choiceText}">
+                                                	<span class="option-text">${choiceDto.choiceText}</span>
+                                                </c:if>
+                                                
+                                                <!-- 선택지 이미지 -->
+                                                <c:if test="${not empty choiceDto.choiceImage}">
+                                                	<img src="${choiceDto.choiceImage}" alt="Choice Image" class="option-image">
+                                                </c:if>
+                                                
+                                            </label>
+                    					</c:when>				
+                    				</c:choose>			
+                    			</c:forEach>
+                    			
+                    		</div>        
+                        </div>
+                    </c:forEach>
+                    
+                </div>
+            </div>
+        </form>
+    </div>
+
+	<script src="<c:url value="/resources/js/exam_page.js"/>"></script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/exam/main.jsp
+++ b/src/main/webapp/WEB-INF/views/exam/main.jsp
@@ -31,7 +31,7 @@
                 <select id="examType" class="styled-select">
                     <option value="" selected disabled>시험을 선택하세요</option>
                     <c:forEach items="${examtypes}" var="type">
-	                    <option value="${type.examTypeCode}">${type.examTypeName}</option>
+                        <option value="${type.examTypeCode}">${type.examTypeName}</option>
                     </c:forEach>
                 </select>
             </div>

--- a/src/main/webapp/resources/css/exam_page.css
+++ b/src/main/webapp/resources/css/exam_page.css
@@ -1,0 +1,276 @@
+@charset "UTF-8";
+/* 기본 설정 */
+body {
+    font-family: 'Malgun Gothic', '맑은 고딕', sans-serif;
+    background-color: #f4f7f6;
+    margin: 0;
+    padding-top: 80px;
+    color: #333;
+}
+
+.exam-container {
+    max-width: 900px; 
+    margin: 0 auto;
+}
+
+/* 상단 고정 헤더 (타이머 및 제출 버튼) */
+.exam-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 70px;
+    background-color: #fff;
+    border-bottom: 1px solid #ddd;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 30px;
+    z-index: 1000;
+}
+
+.exam-title {
+    font-size: 1.5em;
+    color: #2c3e50;
+    margin: 0;
+}
+
+.exam-title a {
+	color: inherit; /* 부모(h1)의 색상 계승 */
+	text-decoration: none;
+}
+
+.timer-box {
+    font-size: 1.4em; 
+    font-weight: bold;
+    color: #e74c3c;
+    background-color: #fceceb;
+    padding: 6px 15px; 
+    border-radius: 5px;
+}
+
+.submit-button {
+    background-color: #3498db;
+    color: white;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 5px;
+    font-size: 1em;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.submit-button:hover {
+    background-color: #2980b9;
+}
+
+/* 문제 영역 레이아웃 */
+.exam-content-wrapper {
+    padding: 20px;
+}
+
+.question-area {
+    width: 100%;
+    background-color: #fff;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-sizing: border-box;
+}
+
+/* 문제 및 선택지 스타일 */
+.question-item {
+    margin-bottom: 35px;
+    padding-bottom: 15px;
+    border-bottom: 1px dashed #ddd;
+}
+
+.question-number {
+    font-size: 1.1em; 
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 15px;
+    line-height: 1.5;
+}
+
+.options-group {
+    padding: 0;
+    margin: 0;
+}
+
+/* 선택지 전체 클릭 가능 및 레이아웃 설정 */
+.option-label.full-click {
+    display: flex;
+    align-items: flex-start;
+    cursor: pointer;
+    padding: 8px 10px;
+    margin: 6px 0;
+    border-radius: 4px;
+    transition: background-color 0.15s;
+}
+
+.option-label.full-click:hover {
+    background-color: #f0f4f7;
+}
+
+.option-label input[type="radio"] {
+    display: none;
+}
+
+/* PC/기본 환경에서의 보기 번호 스타일 */
+.omr-bubble {
+    display: flex; 
+    justify-content: center;
+/*     align-items: center; */
+    
+    width: 1.5em; 
+    height: 1.5em; 
+    font-size: 0.95em; 
+    
+    border-radius: 50%;
+    border: 1px solid #ddd;
+    background-color: #f7f7f7;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+    font-weight: bold;
+    color: #555;
+    flex-shrink: 0;
+    margin-right: 12px;
+}
+
+.omr-bubble:hover {
+    background-color: #eee;
+}
+
+/* 선택되었을 때의 시각적 피드백 */
+.option-label input[type="radio"]:checked + .omr-bubble {
+    background-color: #3498db; 
+    color: white;
+    border-color: #3498db;
+}
+
+.option-text {
+    font-size: 0.95em; 
+    line-height: 1.5;
+    color: #333;
+    flex-grow: 1;
+}
+
+/* 선택된 라벨 전체에 스타일 적용 */
+.option-label.full-click:has(input[type="radio"]:checked) {
+    background-color: #eaf4fb;
+}
+
+/* 공통 지문 박스 */
+.common-text-box {
+    margin: 20px 0 30px;
+    padding: 25px;
+    border: 1px solid #cceeff;
+    background-color: #f7faff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.03);
+}
+
+.text-range {
+    font-weight: bold;
+    color: #3498db;
+    margin-bottom: 15px;
+    font-size: 0.95em;
+    border-bottom: 1px dashed #cceeff;
+    padding-bottom: 8px;
+    text-align: left; 
+}
+
+/* 지문 내용 (공통 및 단독 모두 사용) */
+.text-content {
+/*     white-space: pre-wrap; 지문 내 개행 문자(\n)가 적용되도록 유지 */
+    font-size: 0.85em;
+    line-height: 1.9;
+    color: #2c3e50;
+    text-align: left !important; 
+}
+
+/* 단독 지문이 들어가는 박스 (이미지 포함) */
+.question-media-box {
+    margin: 15px 0 20px;
+    padding: 15px;
+    border: 1px dashed #ddd;
+    background-color: #fafafa;
+    border-radius: 5px;
+    text-align: left; 
+}
+
+/* 지문 이미지 스타일 */
+.question-image {
+    max-width: 80%;
+    height: auto;
+    display: block;
+    margin: 0 auto; 
+    border-radius: 4px;
+    user-select: none; /* 클릭 시 커서 깜빡임 방지 */
+}
+
+/* 선택지 이미지 스타일 */
+.option-image {
+    max-width: 100%;
+    height: auto;
+    margin-top: 5px; /* 선택지 내용과의 간격 */
+    border: 1px solid #eee;
+    padding: 5px;
+}
+
+
+/* 4. 반응형 디자인 (모바일 환경) */
+@media (max-width: 768px) {
+    .exam-header {
+        padding: 0 15px;
+        height: 60px;
+    }
+    .exam-title {
+        font-size: 1.05em;
+    }
+    .timer-box {
+        font-size: 1.2em; 
+        padding: 4px 10px;
+    }
+    .submit-button {
+        padding: 7px 12px;
+        font-size: 0.85em;
+    }
+    .question-area {
+        padding: 15px;
+    }
+    .option-label.full-click {
+        padding: 6px 8px;
+        margin: 4px 0;
+    }
+    
+    /* 모바일 omr-bubble 최종 크기 */
+    .omr-bubble {
+        width: 1.3em; 
+        height: 1.3em;
+        font-size: 0.8em; 
+        margin-right: 10px;
+    }
+    
+    /* 모바일 옵션 텍스트 최종 크기 */
+    .option-text {
+        font-size: 0.85em; 
+    }
+    
+    .common-text-box {
+        padding: 15px;
+        margin: 15px 0 20px;
+    }
+    
+    .text-content {
+        font-size: 0.85em;
+        line-height: 1.9;
+        text-align: left !important; 
+    }
+    
+    .question-media-box {
+        margin: 10px 0 15px;
+        padding: 10px;
+    }
+}

--- a/src/main/webapp/resources/js/exam_page.js
+++ b/src/main/webapp/resources/js/exam_page.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+	alert('⏰ 제한 시간은 60분이며, 시간이 종료되면 자동 제출됩니다.')
+
+    /* 시험 타이머
+    ================================================== */
+    const timer = document.querySelector("#timer")
+    let timeLimit = 60 * 60 // 60분
+    const countdown = setInterval(() => {
+        const minutes = Math.floor(timeLimit / 60)
+        const seconds = timeLimit % 60
+
+        if(timeLimit < 0){
+            clearInterval(countdown)
+            timer.textContent = "시험 종료"
+            alert("시험 시간이 종료되었습니다. 시험이 자동 제출됩니다.")
+            document.querySelector("#examForm").submit()
+        }
+
+        // 00:00 형식으로 표시
+        timer.textContent = 
+            (minutes < 10 ? '0' + minutes : minutes) + ':' +
+            (seconds < 10 ? '0' + seconds : seconds)
+
+        timeLimit--
+    }, 1000)
+    
+})


### PR DESCRIPTION
## 📌 변경 사항
- 시험 응시 화면 UI 구성
- 시험지 제목, 공통 지문, 문제 본문, 문제 이미지, 선택지 정보 출력
- 이미지 파일 경로를 컨트롤러를 통해 동적으로 반환
- 시험 제출 버튼 추가
- 시험지 정보(제목) 클릭 시 메인 페이지(`/`)로 이동하도록 링크 처리
- 이미지 저장소 경로를 환경 설정(`application.properties`)에서 동적으로 불러오도록 구현

## 🛠️ 수정한 이유
- 사용자가 실제 시험에 응시할 수 있는 화면(UI)을 구성
- DB에 저장된 문제지, 문항, 이미지 등을 기반으로 실질적인 응시 경험 제공
- 로컬/운영 등 환경에 따라 이미지 저장 위치가 달라지므로, 동적인 이미지 경로 처리 방식 필요
- 이후 시험 제출, 채점, 결과 저장 등의 기능 개발을 위한 기반 마련

## 🔍 주요 변경 파일
- ExamSelectionController.java
- ExamSelectionService.java
- ExamSelectionDao.java

- ExamCommonpassageDto.java 
- ExamPageDto.java 
- ExamQuestionDto.java
- GedExamParser.java

- ExamSelectionmapper.xml

- exam_page.jsp
- exam_page.css
- exam_page.js

## ✅ 테스트 내용
- [x] 시험지, 문제, 공통 지문이 JSP에 정상 표시되는지 확인
- [x] 이미지가 환경 설정에 따라 올바른 경로에서 로드되는지 확인
- [x] 제출 버튼 클릭 시 폼 전송 동작 확인 (동작만 확인, 기능 구현은 미포함)
- [x] 기존 화면 및 기능에 영향 없는지 확인
- [x] 시험 제목 클릭 시 메인 페이지로 정상 이동되는지 확인

## 🔗 관련 이슈
closes #15 
