### PR TITLE
[BUG] 시험지 PDF 업로드 후 정답 데이터 부재 시 문항 수정 오류

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ target/
 .project
 .springBeans
 sql/
+.idea/
 
 # External tool builders
 .externalToolBuilders/

--- a/src/main/java/com/my/ex/controller/ExamSelectionController.java
+++ b/src/main/java/com/my/ex/controller/ExamSelectionController.java
@@ -381,7 +381,9 @@ public class ExamSelectionController {
 		
 		// 3. 정답지
 		ExamAnswerDto answer = answerService.getAnswerByQuestionId(questionId);
-		answer.setQuestionNum(question.getQuestionNum());
+		if(answer != null) {
+			answer.setQuestionNum(question.getQuestionNum());
+		}
 		
 		// 4. 폴더id
 		int folderId = service.findFolderIdByExamId(examId);
@@ -432,6 +434,5 @@ public class ExamSelectionController {
 				+ "examTypeKor=" + examTypeKor + "&"
 				+ "examRound=" + examRound + "&"
 				+ "examSubject=" + examSubject;
-		
 	}
 }

--- a/src/main/java/com/my/ex/dao/ExamAnswerDao.java
+++ b/src/main/java/com/my/ex/dao/ExamAnswerDao.java
@@ -48,8 +48,8 @@ public class ExamAnswerDao implements IExamAnswerDao {
 	}
 
 	@Override
-	public void updateQuestionAnswer(ExamAnswerDto answerDto) {
-		session.update(NAMESPACE + "updateQuestionAnswer", answerDto);
+	public void updateQuestionAnswer(ExamAnswerDto dto) {
+		session.update(NAMESPACE + "updateQuestionAnswer", dto);
 	}
 
 }

--- a/src/main/java/com/my/ex/dao/IExamAnswerDao.java
+++ b/src/main/java/com/my/ex/dao/IExamAnswerDao.java
@@ -15,5 +15,5 @@ public interface IExamAnswerDao {
 	int updateAnswers(ExamAnswerDto answerDto);
 	List<ExamAnswerDto> getAnswersByQuestionIds(List<Integer> questionIds);
 	ExamAnswerDto getAnswerByQuestionId(Integer questionId);
-	void updateQuestionAnswer(ExamAnswerDto answerDto);
+	void updateQuestionAnswer(ExamAnswerDto dto);
 }

--- a/src/main/java/com/my/ex/dto/ExamAnswerDto.java
+++ b/src/main/java/com/my/ex/dto/ExamAnswerDto.java
@@ -14,8 +14,16 @@ public class ExamAnswerDto {
 	// 🔥response용으로만 쓰이는 필드
 	private int questionNum;
 
+	
 	public ExamAnswerDto(int answerId, int correctAnswer) {
 		this.answerId = answerId;
 		this.correctAnswer = correctAnswer;
-	}		
+	}
+	
+	public ExamAnswerDto(int questionId, int correctAnswer, int examId) {
+		this.questionId = questionId;
+		this.correctAnswer = correctAnswer;
+		this.examId = examId;
+	}
+
 }

--- a/src/main/java/com/my/ex/service/ExamAnswerService.java
+++ b/src/main/java/com/my/ex/service/ExamAnswerService.java
@@ -158,9 +158,18 @@ public class ExamAnswerService implements IExamAnswerService {
 		return dao.getAnswerByQuestionId(questionId);
 	}
 	
-	public void updateQuestionAnswer(QuestionAnswer answer) {
-		ExamAnswerDto dto = new ExamAnswerDto(answer.getAnswerId(), answer.getCorrectAnswer());
-		dao.updateQuestionAnswer(dto);
+	public void updateQuestionAnswer(Integer questionId, QuestionAnswer answer, Integer examId) {
+		Integer answerId = answer.getAnswerId();
+		int correctAnswer = answer.getCorrectAnswer();
+		
+		if((answerId == null || answerId == 0) 
+				&& correctAnswer > 0) {
+			ExamAnswerDto dto = new ExamAnswerDto(questionId, correctAnswer, examId);
+			dao.saveParsedAnswerData(dto);
+		} else {
+			ExamAnswerDto dto = new ExamAnswerDto(answerId, correctAnswer);
+			dao.updateQuestionAnswer(dto);
+		}
 	}
 
 }

--- a/src/main/java/com/my/ex/service/ExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/ExamSelectionService.java
@@ -472,7 +472,10 @@ public class ExamSelectionService implements IExamSelectionService {
 	public void updateExamByForm(ExamCreateRequestDto request) {
 		updateQuestion(request.getExamInfo(), request.getQuestion(), request.getFileMap());
 		updateQuestionChoices(request.getQuestion().getQuestionChoices());
-		answerService.updateQuestionAnswer(request.getQuestion().getQuestionAnswer());
+		answerService.updateQuestionAnswer(
+				request.getQuestion().getQuestionId(),
+				request.getQuestion().getQuestionAnswer(),
+				request.getExamInfo().getExamId());
 	}
 	
 	private void updateQuestion(CreateExamInfo i, Question q, Map<String, MultipartFile> fileMap) {

--- a/src/main/webapp/resources/js/admin_exam_edit_page.js
+++ b/src/main/webapp/resources/js/admin_exam_edit_page.js
@@ -352,12 +352,13 @@ const QuestionEditHandler = {
 
                 axios.post('/exam/updateExamByForm', formData)
                     .then(response => {
+                        alert('수정이 완료되었습니다.')
                         location.href = response.data
                     })
                     .catch(error => {
                         console.error(error)
                         alert('수정 중 오류가 발생했습니다.\n메인페이지로 이동합니다.')
-                        // window.location.href = '/'
+                        window.location.href = '/'
                     })
             }
         }
@@ -416,9 +417,11 @@ const QuestionEditHandler = {
             }))
 
             // 정답
-            this.questionObj.questionAnswer = {
-                answerId: p.examAnswer.answerId,
-                correctAnswer: parseInt(p.examAnswer.correctAnswer)
+            if(p.examAnswer){
+                this.questionObj.questionAnswer = {
+                    answerId: p.examAnswer.answerId,
+                    correctAnswer: parseInt(p.examAnswer.correctAnswer)
+                }
             }
         } catch (error) {
             console.error("데이터 파싱 중 오류 발생: ", error)


### PR DESCRIPTION
## 📌 변경 사항
- 프론트엔드 방어 코드 추가: 수정 페이지 초기화(`_parseExamData`) 시 정답 데이터(`examAnswer`) 존재 여부를 확인하는 방어 코드를 추가함. 데이터가 부재한 경우 `answerId`는 `null`, `correctAnswer`는 빈 값으로 유지하여 예외 발생을 방지하고 신규 등록이 가능한 상태로 초기화함

- **서버 Upsert 로직 구현:** 서비스 레이어의 `updateQuestionAnswer` 메서드에서 `answerId` 유무와 `correctAnswer` 값을 체크하여, 기존 데이터가 없으면 **INSERT**(`saveParsedAnswerData`), 있으면 **UPDATE**(`updateQuestionAnswer`)를 수행하도록 분기 처리.

## 🛠️ 수정한 이유
- **예외 상황 대응:** 시험지 PDF 업로드 기능을 통해 문항만 자동 추출된 경우, 정답 데이터가 DB에 존재하지 않아 수정 페이지 진입 및 저장 시 `NullPointerException` 및 경로 에러가 발생하는 문제 해결
- **기능적 유연성 확보:** 정답이 없는 문항에 대해서도 수정 페이지를 통해 수동으로 정답을 등록하고 DB에 반영할 수 있는 구조 마련

## 🔍 주요 변경 파일
- ExamSelectionController.java
- ExamSelectionService.java
- ExamAnswerService.java
- admin_exam_edit_page.js

## ✅ 테스트 내용
- [x] 정답지가 없는 시험지(PDF 업로드 직후)에서 수동 정답 입력 후 저장 시 DB에 INSERT 되는지 확인
- [x] 이미 정답이 등록된 시험지에서 정답 수정 시 기존 레코드가 UPDATE 되는지 확인
- [x] 정답 데이터 부재 시에도 수정 페이지가 정상적으로 렌더링되는지 확인

## 🔗 관련 이슈
closes #26 