### PR TITLE
[ENH] 시험 유형 및 과목 조회 시 유효 데이터 필터링 로직 강화

### DIFF
--- a/src/main/java/com/my/ex/controller/ExamSelectionController.java
+++ b/src/main/java/com/my/ex/controller/ExamSelectionController.java
@@ -13,7 +13,6 @@ import com.my.ex.dto.request.MoveExamsToFolderDto;
 import com.my.ex.dto.response.ExamInfoGroup;
 import com.my.ex.dto.response.ExamPageDto;
 import com.my.ex.dto.response.ExamPdfPreview;
-import com.my.ex.dto.response.ExamResultDto;
 import com.my.ex.parser.geomjeong.parse.exam.GeomjeongExamParser;
 import com.my.ex.service.IExamAnswerService;
 import com.my.ex.service.IExamSelectionService;

--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -4,11 +4,18 @@
   "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.my.ex.ExamSelectionMapper">
 
+	<!-- 정답지를 제외하고 시험지 유형만 가져옴 -->
 	<select id="getExamTypes" resultType="ExamTypeDto">
 		SELECT exam_type_code,
 			   exam_type_name
 		  FROM exam_type
 		 WHERE is_deleted = 0
+		   AND exam_type_code NOT LIKE '%Answer'
+		   AND exam_type_id IN (
+		   		SELECT exam_type_id
+		   		  FROM exam_info
+		   		 WHERE isdeleted = 'N'
+		   )
 		 ORDER BY exam_type_id
 	</select>
 	
@@ -57,17 +64,31 @@
 	</select>
 	
 	<!-- 특정 시험 회차에 대해 등록된 시험 과목을 불러옴  -->
+	<!-- 정답지와 연결된 시험지의 과목만 불러옴 -->
 	<select id="getSubjectsByExamRound" parameterType="java.util.HashMap" resultType="String">
-		SELECT distinct exam_subject
-		  FROM exam_info
-		 WHERE exam_type_id = (
+		SELECT DISTINCT i.exam_subject
+		  FROM exam_info i
+		 WHERE i.exam_type_id = (
 		 	SELECT exam_type_id
 			  FROM exam_type
 			 WHERE exam_type_code = #{examTypeCode}
 		 )
-		   AND exam_round = #{examRound}
-		   AND isdeleted = 'N'
-		 ORDER BY exam_subject
+		   AND i.exam_round = #{examRound}
+		   AND i.isdeleted = 'N'
+		   AND EXISTS (
+		   	   SELECT 1
+		   	     FROM exam_info info
+		   	     JOIN exam_answer a ON a.exam_id = info.exam_id
+		   	    WHERE info.exam_type_id = (
+		   	    	SELECT exam_type_id
+		   	    	  FROM exam_type
+		   	    	 WHERE exam_type_code = CONCAT(#{examTypeCode}, 'Answer')
+		   	    )
+		   	      AND info.exam_round = i.exam_round
+		   	      AND info.exam_subject = i.exam_subject
+		   	      AND info.isdeleted = 'N'
+		   )
+		 ORDER BY i.exam_subject
 	</select>
 	
 	<!-- 특정 폴더에 있는 모든 시험지/정답지 정보 가져옴 -->


### PR DESCRIPTION
## 📌 변경 사항
- **시험 유형 조회(getExamTypes) 필터링 로직 고도화**
  - `NOT LIKE`를 사용하여 코드명에 'Answer'가 포함된 정답지 전용 유형을 제외함
  - `IN` 서브쿼리를 통해 `exam_info`에 실제 문항 데이터가 등록된 유형만 반환하도록 수정
- **응시 과목 조회(getSubjectsByExamRound) 조건 정교화**
  - `EXISTS`와 `JOIN`을 활용하여 `exam_answer` 테이블에 정답 세트가 구축된 과목만 동적으로 노출
  - `CONCAT` 함수를 활용해 사용자가 선택한 시험지 코드에 'Answer'를 실시간으로 결합하여 대응하는 정답지 데이터를 동적으로 매칭

## 🛠️ 수정한 이유
- **사용자 혼선 방지:** 응시 대상이 아닌 정답지 데이터가 메인 화면 목록에 노출되는 UX 결함을 해결하기 위함
- **서비스 안정성 강화:** 시험 정보만 있고 정답 데이터가 없는 '미완성 시험지'를 사전에 필터링하여, 사용자가 문제 풀이 후 채점 불가 에러를 겪지 않도록 방어 로직 구축

## 🔍 주요 변경 파일
- ExamSelectionmapper.xml

## ✅ 테스트 내용
- [x] 메인 화면에서 '정답표'가 붙은 시험 유형이 사라졌는지 확인
- [x] `exam_answer` 데이터를 임의로 삭제했을 때, 해당 과목이 목록에서 실시간으로 제외되는지 확인
- [x] `CONCAT`을 통한 시험지-정답지 코드 매칭 정상 동작 확인

## 🔗 관련 이슈
closes #30 
