### PR TITLE
[ENH] 시험 유형 및 과목 조회 시 유효 데이터 필터링 로직 강화 v1

### DIFF
--- a/src/main/java/com/my/ex/controller/AdminController.java
+++ b/src/main/java/com/my/ex/controller/AdminController.java
@@ -234,7 +234,7 @@ public class AdminController {
 	
 	@GetMapping("/createExamPage")
 	public String createExamPage(Model model, int folderId) {
-		List<ExamTypeDto> list = examService.getExamTypes();
+		List<ExamTypeDto> list = examService.getExamPaperTypes();
 		model.addAttribute("examtypes", list);
 		return "/admin/exam_create_page";
 	}

--- a/src/main/java/com/my/ex/controller/ExamSelectionController.java
+++ b/src/main/java/com/my/ex/controller/ExamSelectionController.java
@@ -61,6 +61,12 @@ public class ExamSelectionController {
 		return service.getExamTypes();
 	}
 	
+	@GetMapping("/getAllExamTypes")
+	@ResponseBody
+	public List<ExamTypeDto> getAllExamTypes(){
+		return service.getAllExamTypes();
+	}
+	
 	@GetMapping("/getExamRounds")
 	@ResponseBody
 	public ExamInfoGroup getExamInfo(@RequestParam String examTypeCode) {

--- a/src/main/java/com/my/ex/dao/ExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/ExamSelectionDao.java
@@ -25,6 +25,16 @@ public class ExamSelectionDao implements IExamSelectionDao {
 	public List<ExamTypeDto> getExamTypes() {
 		return session.selectList(NAMESPACE + "getExamTypes");
 	}
+	
+	@Override
+	public List<ExamTypeDto> getAllExamTypes() {
+		return session.selectList(NAMESPACE + "getAllExamTypes");
+	}
+
+	@Override
+	public List<ExamTypeDto> getExamPaperTypes() {
+		return session.selectList(NAMESPACE + "getExamPaperTypes");
+	}
 
 	@Override
 	public List<String> getExamRounds(String examTypeCode) {

--- a/src/main/java/com/my/ex/dao/IExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/IExamSelectionDao.java
@@ -11,6 +11,8 @@ import java.util.Map;
 
 public interface IExamSelectionDao {
 	List<ExamTypeDto> getExamTypes();
+	List<ExamTypeDto> getAllExamTypes();
+	List<ExamTypeDto> getExamPaperTypes();
 	List<String> getExamRounds(String examTypeCode);
 	List<String> getSubjectsByExamRound(Map<String, String> map);
 	List<ExamTitleDto> getAllExamTitlesByFolderId(int folderId);

--- a/src/main/java/com/my/ex/service/ExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/ExamSelectionService.java
@@ -67,6 +67,16 @@ public class ExamSelectionService implements IExamSelectionService {
 	public List<ExamTypeDto> getExamTypes() {
 		return dao.getExamTypes();
 	}
+	
+	@Override
+	public List<ExamTypeDto> getAllExamTypes() {
+		return dao.getAllExamTypes();
+	}
+
+	@Override
+	public List<ExamTypeDto> getExamPaperTypes() {
+		return dao.getExamPaperTypes();
+	}
 
 	@Override
 	public List<String> getExamRounds(String examTypeCode) {

--- a/src/main/java/com/my/ex/service/IExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/IExamSelectionService.java
@@ -18,6 +18,8 @@ import com.my.ex.dto.service.ParsedExamData;
 
 public interface IExamSelectionService {
 	List<ExamTypeDto> getExamTypes();
+	List<ExamTypeDto> getAllExamTypes();
+	List<ExamTypeDto> getExamPaperTypes();
 	List<String> getExamRounds(String examTypeCode);
 	List<String> getSubjectsByExamRound(String examTypeCode, String examRound);
 	List<ExamTitleDto> getAllExamTitlesByFolderId(int folderId);

--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -4,7 +4,7 @@
   "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.my.ex.ExamSelectionMapper">
 
-	<!-- 정답지를 제외하고 시험지 유형만 가져옴 -->
+	<!-- 사용자용: 정답지를 제외하고 시험지 유형만 가져옴 -->
 	<select id="getExamTypes" resultType="ExamTypeDto">
 		SELECT exam_type_code,
 			   exam_type_name
@@ -16,6 +16,25 @@
 		   		  FROM exam_info
 		   		 WHERE isdeleted = 'N'
 		   )
+		 ORDER BY exam_type_id
+	</select>
+	
+	<!-- 관리자용: 시험지 및 정답지 PDF 업로드시 전체 유형 가져옴 (시험지 + 정답지 유형 포함) -->
+	<select id="getAllExamTypes" resultType="ExamTypeDto">
+		SELECT exam_type_code,
+			   exam_type_name
+		  FROM exam_type
+		 WHERE is_deleted = 0
+		 ORDER BY exam_type_id
+	</select>
+	
+	<!-- 관리자용: 시험지 수동 등록 시 정답지(Answer) 유형을 제외한 시험지 유형만 조회 -->
+	<select id="getExamPaperTypes" resultType="ExamTypeDto">
+		SELECT exam_type_code,
+			   exam_type_name
+		  FROM exam_type
+		 WHERE is_deleted = 0
+		   AND exam_type_code NOT LIKE '%Answer'
 		 ORDER BY exam_type_id
 	</select>
 	

--- a/src/main/webapp/resources/js/admin_main.js
+++ b/src/main/webapp/resources/js/admin_main.js
@@ -894,7 +894,7 @@ const validateExamInfo = () => {
 
 // 시험 유형 가져오기
 const fetchGetExamTypes = () => {
-    axios.get('/exam/getExamTypes')
+    axios.get('/exam/getAllExamTypes')
         .then(response => {
             updateExamTypes(response.data)
         })

--- a/src/main/webapp/resources/js/exam_page.js
+++ b/src/main/webapp/resources/js/exam_page.js
@@ -21,8 +21,7 @@ const submitHandler = {
                 this._showResult(
                     response.data.result,
                     response.data.totalScore,
-                    false)
-                    // response.data.isPassed)
+                    response.data.isPassed)
             })
             .catch(error => {
                 console.error('error: ', error)


### PR DESCRIPTION
## 📌 변경 사항
**1. 시험 유형 조회 로직의 세분화 및 고도화**
기존에 공통으로 사용되던 시험 유형 조회 쿼리를 호출 주체(사용자/관리자) 및 등록 방식에 따라 3가지로 분리하여 비즈니스 로직의 정확성을 높임
- `getExamTypes` **(사용자 응시용)**
  - `NOT LIKE '%Answer'`를 사용하여 정답지 유형 제외
  - `IN` 서브쿼리를 통해 실제 문항 데이터(`exam_info`)가 등록된 **'응시 가능한' 유형**만 반환
- `getAllExamTypes` **(관리자 PDF 업로드용)**
  - 시험지 PDF와 정답지 PDF를 개별 등록해야 하는 특성에 맞춰 정답지 유형을 포함한 **전체 목록** 반환
- `getExamPaperTypes` **(관리자 수동 등록용)**
  - 문제와 정답을 동시에 입력하는 방식이므로, 정답지 전용 유형을 제외한 **순수 시험지 유형**만 반환

## 🛠️ 수정한 이유
- **관리자 운영 효율화:** PDF 업로드와 수동 등록이라는 서로 다른 관리자 워크플로우에 최적화된 선택지를 제공

## 🔍 주요 변경 파일
- AdminController.java
- ExamSelectionController.java
- ExamSelectionDao.java
- ExamSelectionService.java
- ExamSelectionmapper.xml
- admin_main.js

## ✅ 테스트 내용
- [x] **관리자 PDF 등록:** 시험지와 정답지 유형이 모두 조회되어 정상적으로 업로드 가능한지 확인
- [x] **관리자 수동 등록:** 정답지 유형이 제외된 시험지 전용 목록이 정상 출력되는지 확인

## 🔗 관련 이슈
closes #31 
