### PR TITLE
[FEAT] 폴더 내 시험지 다중 조건 검색 및 필터링 기능 구현

### DIFF
--- a/src/main/java/com/my/ex/controller/AdminController.java
+++ b/src/main/java/com/my/ex/controller/AdminController.java
@@ -54,6 +54,7 @@ public class AdminController {
 	public String adminMainPage(Model model) {
 		// 시험 종류, 시험 회차, 시험 과목 불러오기
 //		model.addAttribute("examList", examService.getAllExamTitles());
+		model.addAttribute("examtypes", examService.getAllExamTypes());
 		model.addAttribute("folderList", service.getFolderList()); 
 		
 		return "/admin/main";

--- a/src/main/java/com/my/ex/controller/ExamSelectionController.java
+++ b/src/main/java/com/my/ex/controller/ExamSelectionController.java
@@ -7,12 +7,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.my.ex.config.EnvironmentConfig;
 import com.my.ex.dto.*;
 import com.my.ex.dto.request.ExamCreateRequestDto;
+import com.my.ex.dto.request.ExamSearchDto;
 import com.my.ex.dto.request.ExamCreateRequestDto.CreateExamInfo;
 import com.my.ex.dto.request.ExamCreateRequestDto.Question;
 import com.my.ex.dto.request.MoveExamsToFolderDto;
 import com.my.ex.dto.response.ExamInfoGroup;
 import com.my.ex.dto.response.ExamPageDto;
 import com.my.ex.dto.response.ExamPdfPreview;
+import com.my.ex.dto.response.ExamTitleDto;
 import com.my.ex.parser.geomjeong.parse.exam.GeomjeongExamParser;
 import com.my.ex.service.IExamAnswerService;
 import com.my.ex.service.IExamSelectionService;
@@ -438,5 +440,11 @@ public class ExamSelectionController {
 	@ResponseBody
 	public Map<String, Object> checkAnswers(@RequestParam Map<String, Object> map) {
 		return answerService.checkAnswers(map);
+	}
+	
+	@GetMapping("/searchExams")
+	@ResponseBody
+	public List<ExamTitleDto> searchExams(ExamSearchDto dto) {
+		return service.searchExams(dto);
 	}
 }

--- a/src/main/java/com/my/ex/dao/ExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/ExamSelectionDao.java
@@ -11,6 +11,7 @@ import com.my.ex.dto.ExamChoiceDto;
 import com.my.ex.dto.ExamInfoDto;
 import com.my.ex.dto.ExamQuestionDto;
 import com.my.ex.dto.ExamTypeDto;
+import com.my.ex.dto.request.ExamSearchDto;
 import com.my.ex.dto.response.ExamTitleDto;
 
 @Repository
@@ -169,6 +170,11 @@ public class ExamSelectionDao implements IExamSelectionDao {
 	@Override
 	public int getExamTypeIdByExamTypeCode(String examTypeCode) {
 		return session.selectOne(NAMESPACE + "getExamTypeIdByExamTypeCode", examTypeCode);
+	}
+
+	@Override
+	public List<ExamTitleDto> searchExams(ExamSearchDto dto) {
+		return session.selectList(NAMESPACE + "searchExams", dto);
 	}
 
 }

--- a/src/main/java/com/my/ex/dao/IExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/IExamSelectionDao.java
@@ -4,6 +4,7 @@ import com.my.ex.dto.ExamChoiceDto;
 import com.my.ex.dto.ExamInfoDto;
 import com.my.ex.dto.ExamQuestionDto;
 import com.my.ex.dto.ExamTypeDto;
+import com.my.ex.dto.request.ExamSearchDto;
 import com.my.ex.dto.response.ExamTitleDto;
 
 import java.util.List;
@@ -40,4 +41,5 @@ public interface IExamSelectionDao {
 	int getExamIdByExamTypeId(Map<String, Object> map);
 	List<Integer> getQuestionIdByExamId(int examId);
 	int getExamTypeIdByExamTypeCode(String examTypeCode);
+	List<ExamTitleDto> searchExams(ExamSearchDto dto);
 }

--- a/src/main/java/com/my/ex/dto/request/ExamSearchDto.java
+++ b/src/main/java/com/my/ex/dto/request/ExamSearchDto.java
@@ -1,0 +1,13 @@
+package com.my.ex.dto.request;
+
+import lombok.Data;
+
+@Data
+public class ExamSearchDto {
+	private String keyword;
+	private String type;
+	private String subject;
+	private String year;
+	private String round;
+	private int activeFolderId;
+}

--- a/src/main/java/com/my/ex/service/ExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/ExamSelectionService.java
@@ -34,6 +34,7 @@ import com.my.ex.dto.request.ExamCreateRequestDto.Question;
 import com.my.ex.dto.request.ExamCreateRequestDto.Question.CommonPassage;
 import com.my.ex.dto.request.ExamCreateRequestDto.Question.IndividualPassage;
 import com.my.ex.dto.request.ExamCreateRequestDto.Question.QuestionChoice;
+import com.my.ex.dto.request.ExamSearchDto;
 import com.my.ex.dto.response.ExamPageDto;
 import com.my.ex.dto.response.ExamTitleDto;
 import com.my.ex.dto.service.ParsedExamData;
@@ -597,6 +598,11 @@ public class ExamSelectionService implements IExamSelectionService {
 	@Override
 	public int getExamTypeIdByExamTypeCode(String examTypeCode) {
 		return dao.getExamTypeIdByExamTypeCode(examTypeCode);
+	}
+
+	@Override
+	public List<ExamTitleDto> searchExams(ExamSearchDto dto) {
+		return dao.searchExams(dto);
 	}
 
 }

--- a/src/main/java/com/my/ex/service/IExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/IExamSelectionService.java
@@ -12,6 +12,7 @@ import com.my.ex.dto.ExamInfoDto;
 import com.my.ex.dto.ExamQuestionDto;
 import com.my.ex.dto.ExamTypeDto;
 import com.my.ex.dto.request.ExamCreateRequestDto;
+import com.my.ex.dto.request.ExamSearchDto;
 import com.my.ex.dto.response.ExamPageDto;
 import com.my.ex.dto.response.ExamTitleDto;
 import com.my.ex.dto.service.ParsedExamData;
@@ -47,4 +48,5 @@ public interface IExamSelectionService {
 	void updateExamByForm(ExamCreateRequestDto request);
 	int getExamIdByExamTypeId(String examTypeCode,String examRound, String examSubject);
 	int getExamTypeIdByExamTypeCode(String examTypeCode);
+	List<ExamTitleDto> searchExams(ExamSearchDto dto);
 }

--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -404,4 +404,59 @@
 		 WHERE exam_id = #{examId}
 	</select>
 	
+	<!-- 시험지 검색 -->
+	<select id="searchExams" parameterType="ExamSearchDto" resultType="ExamTitleDto">
+		SELECT
+			 i.exam_type_id AS examTypeId,
+			 t.exam_type_code AS examTypeCode,
+			 t.exam_type_name AS examTypeName, 
+		     
+		     i.exam_id AS examId,
+		     i.exam_round AS examRound,
+		     i.exam_subject AS examSubject,
+		     
+		     CASE
+		     	WHEN t.exam_type_code LIKE '%Answer' THEN
+		     	    (SELECT COUNT(*) 
+		               FROM exam_answer a 
+		              WHERE a.exam_id = i.exam_id)
+		        ELSE
+				    (SELECT COUNT(*) 
+		               FROM exam_question q 
+		              WHERE q.exam_id = i.exam_id)
+			END AS totalCount,
+			
+             i.created_date,
+             f.folder_id
+		  FROM exam_info i
+		  JOIN exam_type t ON i.exam_type_id = t.exam_type_id
+		  JOIN exam_folder f ON i.folder_id = f.folder_id
+		  <where>
+			  	AND f.folder_id = #{activeFolderId}
+			    AND i.isdeleted = 'N'
+			    
+			    <if test="keyword != null and keyword != ''">
+		            AND (t.exam_type_name LIKE '%' || #{keyword} || '%' 
+		            	OR i.exam_subject LIKE '%' || #{keyword} ||'%'
+		            	OR i.exam_round LIKE '%' || #{keyword} ||'%')
+		        </if>
+		        
+		        <if test="type != null and type != ''">
+		            AND t.exam_type_code = #{type}
+		        </if>
+		        
+		        <if test="subject != null and subject != ''">
+		            AND i.exam_subject = #{subject}
+		        </if>
+		        
+		        <if test="year != null and year != ''">
+		            AND i.exam_round LIKE '%' || #{year} || '%'
+		        </if>
+		        
+		        <if test="round != null and round != ''">
+		            AND i.exam_round LIKE '%' || #{round} || '%'
+		        </if>
+		  </where>
+		  ORDER BY i.created_date DESC	
+	</select>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/admin/main.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/main.jsp
@@ -89,30 +89,32 @@
             
 			<!-- 검색 필터 섹션 -->
             <div class="filter-box">
-				<form id="searchForm" class="filter-controls" onsubmit="return false;">
+				<form id="searchForm" class="filter-controls">
 					<div class="input-group main-search">
 						<i class="fas fa-search search-icon"></i>
-						<input type="text" id="searchKeyword" placeholder="시험지 제목, 과목, 유형 등으로 검색하세요" class="form-control">
+						<input type="text" id="searchKeyword" name="keyword" placeholder="시험지 제목, 과목, 유형 등으로 검색하세요" class="form-control">
 						<button type="submit" class="btn btn-search-go">검색</button>
 					</div>
 			
 					<div class="select-group">
-						<select id="filterSubject" class="form-control select-filter">
-							<option value="">전체 과목</option>
-							<option value="국어">국어</option>
-							<option value="수학">수학</option>
-							<option value="영어">영어</option>
+						<select id="selectExamType" name="type" class="form-control select-filter ">
+							<option value="" disabled selected>유형 선택</option>
+							<!-- 서버로부터 받은 데이터로 동적으로 설정 -->
 						</select>
-						<select id="filterGrade" class="form-control select-filter">
-							<option value="">전체 학년</option>
-							<option value="고1">고등학교 1학년</option>
-							<option value="고2">고등학교 2학년</option>
-							<option value="고3">고등학교 3학년</option>
+
+						<select id="selectSubject" name="subject" class="form-control select-filter">
+							<option value="" disabled selected>시험 유형을 선택해주세요</option>
+							<!-- 시험 유형에 따라 동적으로 설정 -->
 						</select>
-						<select id="filterType" class="form-control select-filter">
-							<option value="">전체 유형</option>
-							<option value="모의고사">모의고사</option>
-							<option value="기출">기출</option>
+
+						<select id="selectYear" name="year" class="form-control select-filter">
+							<option value="" disabled selected>시험 유형을 선택해주세요</option>
+							<!-- 현재 연도부터 과거 10년치를 동적으로 설정 -->
+						</select>
+
+						<select id="selectRound" name="round" class="form-control select-filter">
+							<option value="" disabled selected>시험 유형을 선택해주세요</option>
+							<!-- 시험 유형에 따라 동적으로 설정 -->
 						</select>
 					</div>
 				</form>
@@ -269,7 +271,7 @@
 							<div class="form-group">
 								<label><i class="fas fa-calendar-check"></i> 시행 연도</label>
 								<select id="selectYear" class="form-select">
-									<option value="" disabled selected>연도 선택</option>
+									<option value="" disabled selected>시험 유형을 선택해주세요</option>
 									<!-- 현재 연도부터 과거 10년치를 동적으로 설정 -->
 								</select>
 							</div>

--- a/src/main/webapp/resources/css/admin_main.css
+++ b/src/main/webapp/resources/css/admin_main.css
@@ -195,10 +195,11 @@ body {
 .select-group {
     display: flex;
     gap: 15px;
+    flex-wrap: wrap;
 }
 
 .select-filter {
-    flex-grow: 1;
+    flex: 1;
     border: 1px solid #ced4da;
     border-radius: 10px;
     background-color: #fff;
@@ -206,10 +207,19 @@ body {
     padding: 14px 30px 14px 15px;
     font-size: 1em;
     color: #555;
-    background-image: url("data:image:svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20fill%3D%22%2334495e%22%20d%3D%22M8%2011l-4-4h8l-4%204z%22%2F%3E%3C%2Fsvg%3E");
+
+    /* 커스텀 화살표 아이콘 */
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23555555' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
     background-repeat: no-repeat;
-    background-position: right 15px center;
+    background-position: right 12px center;
+    background-size: 12px;
+    
     transition: border-color 0.2s;
+
+    /* 텍스트 넘침 방지 */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 .select-filter:focus {
     outline: none;
@@ -380,6 +390,7 @@ body {
     grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
     gap: 25px;
     margin-bottom: 40px;
+    padding-top: 20px;
 }
 
 .exam-card {


### PR DESCRIPTION
## 📌 변경 사항
- **다중 조건 검색 필터 추가:** 키워드, 시험 유형, 과목, 시행 연도, 시행 회차를 조합하여 검색할 수 있는 기능을 구현
- **MyBatis 동적 쿼리 적용:** 파라미터 존재 여부에 따라 검색 조건을 유연하게 생성하도록 `<where>` 및 `<if>` 태그를 활용한 Mapper 메서드를 추가
- **Form 제출 이벤트 제어:** 검색 버튼 클릭 또는 입력창에서 엔터키 입력 시, 검색어 또는 필터 조건이 존재하면 비동기 검색 함수 `handleSearch`를 실행하도록 폼 제출 이벤트를 제어함
- **반응형 필터 레이아웃:** `.select-group`에 `flex-wrap`을 적용하여 모바일 및 작은 화면에서도 필터 요소들이 컨테이너를 벗어나지 않고 자연스럽게 줄바꿈되도록 수정

## 🛠️ 수정한 이유
- **사용자 편의성 향상:** 폴더 내 시험지가 많아질 경우 특정 시험지를 찾기 어려운 불편함을 해소하기 위해 정교한 필터링을 추가
- **데이터 구조 대응:** `examRound` 컬럼에 문자열로 합쳐진 '연도'와 '회차' 정보를 프론트엔드에서 각각 필터링할 수 있도록 서버 단의 `LIKE` 검색 로직을 추가
- **버그 수정:** 검색창 엔터 입력 시 메인 페이지로 튕기는 UX 저해 요소를 해결하고 표준적인 폼 제출 방식을 적용하기 위함

## 🔍 주요 변경 파일
- AdminController.java
- ExamSelectionController.java
- ExamSelectionDao.java
- ExamSearchDto.java
- ExamSelectionService.java
- ExamSelectionmapper.xml
- /admin/main.jsp
- admin_main.css
- admin_main.js

## ✅ 테스트 내용
- [x] 키워드, 유형, 과목 등 단일/복합 조건 선택 시 검색 결과 정상 출력 확인
- [x] 검색어 입력 후 엔터키 입력 시 페이지 이동 없이 결과만 비동기 갱신되는지 확인
- [x] 브라우저 너비를 줄였을 때 필터 박스들이 아래로 떨어지며 UI가 유지되는지 확인
- [x] 검색 조건이 없을 시 경고창(`alert`) 표시 확인

## 🔗 관련 이슈
closes #33 
