### PR TITLE
[ENH] 정답지 태그 표시 문구 개선 (과목명 -> 과목명 - 정답지)

### DIFF
--- a/src/main/java/com/my/ex/dto/response/ExamTitleDto.java
+++ b/src/main/java/com/my/ex/dto/response/ExamTitleDto.java
@@ -1,10 +1,9 @@
 package com.my.ex.dto.response;
 
-import java.time.LocalDate;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import lombok.Data;
+
+import java.time.LocalDate;
 
 @Data
 public class ExamTitleDto {
@@ -15,6 +14,10 @@ public class ExamTitleDto {
 	private int examId;
 	private String examRound;
 	private String examSubject;
+	/**
+	 * 화면 표시용 과목명 (정답지 여부에 따라 '과목명 - 정답지' 형태로 가공됨)
+	 */
+	private String displaySubject;
 	
 	private int totalCount; // 문항 수
 	

--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -144,6 +144,13 @@
 		               FROM exam_question q 
 		              WHERE q.exam_id = i.exam_id)
 			END AS totalCount,
+
+			CASE
+				WHEN t.exam_type_code LIKE '%Answer' THEN
+					CONCAT(i.exam_subject, ' - 정답지')
+				ELSE
+					i.exam_subject
+			END AS displaySubject,
 			
              i.created_date,
              f.folder_id

--- a/src/main/webapp/resources/js/admin_main.js
+++ b/src/main/webapp/resources/js/admin_main.js
@@ -557,7 +557,7 @@ const renderExamList = (exaxmList, noDataMessage) => {
                     <input type="checkbox" class="exam-select-checkbox" data-exam-id="${examTitleDto.examId}">
 
                     <div class="card-header">
-                        <span class="tag tag-${examTitleDto.examSubject}">${examTitleDto.examSubject}</span>
+                        <span class="tag tag-${examTitleDto.examSubject}">${examTitleDto.displaySubject}</span>
                         <span class="tag tag-round">${examTitleDto.examRound}</span>
                     </div>
                     <h3 class="card-title">${examTitleDto.displayTitle}</h3>


### PR DESCRIPTION
## 📌 변경 사항
- **DTO 필드 추가:** `ExamTitleDto`에 화면 표시 전용 필드인 `displaySubject`를 추가
- **MyBatis 쿼리 고도화:** `getAllExamTitlesByFolderId` 쿼리에서 `CASE WHEN`문을 사용하여 `examTypeCode`가 `Answer`로 끝날 경우 과목명 뒤에 ' - 정답지' 접미사가 붙도록 로직 추가
- **프론트엔드 연동:** `renderExamList` 함수 내 가공된 `displaySubject`가 화면에 출력되도록 반영

## 🛠️ 수정한 이유
- **사용자 혼동 방지:** 폴더 내에 시험지와 정답지가 혼재되어 있을 때, 태그만 보고는 직관적으로 구분하기 어려워 발생하던 관리상의 불편함을 해소하기 위함
- **데이터 일관성:** 원본 데이터(`examSubject`)는 유지하면서, 조회 시점에만 명칭을 가공하여 데이터 무결성과 시인성을 동시에 확보

## 🔍 주요 변경 파일
- ExamTitleDto.java
- ExamSelectionmapper.xml
- admin_main.js

## ✅ 테스트 내용
- [X] 일반 시험지는 기존 과목명대로, 정답지는 '과목명 - 정답지'로 노출되는지 확인
- [X] 체크박스 선택, 삭제, 보기 버튼 등 기존 기능과의 데이터 바인딩 오류 없음 확인

## 🔗 관련 이슈
closes #38 
