### PR TITLE
[FEAT] 문항 선택지 내 서식 적용을 위한 Quill 에디터 도입

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/exam_create_page.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/exam_create_page.jsp
@@ -15,7 +15,8 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
 <!-- Quill 에디터 -->
-<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.bubble.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css" />
 </head>
 <body>
 	<div class="exam_create_page">

--- a/src/main/webapp/WEB-INF/views/admin/exam_edit_page.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/exam_edit_page.jsp
@@ -17,7 +17,8 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
 <!-- Quill 에디터 -->
-<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.bubble.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css" />
 </head>
 <body>
 	<div class="exam_edit_page">
@@ -93,14 +94,21 @@
 							<label>선택지</label>
 							<div class="option-inputs">
 								<c:forEach items="${examPageDto.examChoices}" var="choices">
-									<div class="option-item-${choices.choiceNum}" >
-										<input type="text" 
+									<div class="option-item-${choices.choiceNum} d-flex align-items-center mb-2">
+										<!-- <input type="text" 
 											class="form-control option-input" 
 											data-choice-num="${choices.choiceNum}" 
 											data-choice-id="${choices.choiceId}"
 											placeholder="보기 ${choices.choiceNum}"
 											value="${choices.choiceText}"
-										>
+										> -->
+										<div id="choice-editor-${choices.choiceId}"
+											class="form-control choice-editor"
+											data-choice-num="${choices.choiceNum}"
+											data-choice-id="${choices.choiceId}"
+											contenteditable="true"
+											style="background: #fff;"
+										>${choices.choiceText}</div>
 										<button type="button" class="btn btn-danger btn-sm btn-remove-option">
 											<i class="fas fa-times"></i>
 										</button>

--- a/src/main/webapp/resources/js/admin_exam_create_page.js
+++ b/src/main/webapp/resources/js/admin_exam_create_page.js
@@ -592,14 +592,26 @@ const createQuestionHml = (number) => {
                 <div class="form-group options-group">
                     <label>선택지</label>
                     <div class="option-inputs">
-                        <div class="option-item-1">
-                            <input type="text" class="form-control option-input" data-choice-num="1" placeholder="보기 1">
+                        <div class="option-item-1" d-flex align-items-center mb-2">
+                            <div id="choice-editor-${number}-1" 
+                                class="choice-editor form-control option-input" 
+                                data-choice-num="1"
+                                data-choice-id="${number}-1" 
+                                contenteditable="true" 
+                                style="background: #fff;"
+                            ></div>
                             <button type="button" class="btn btn-danger btn-sm btn-remove-option">
                                 <i class="fas fa-times"></i>
                             </button>
                         </div>
-                        <div class="option-item-2">
-                            <input type="text" class="form-control option-input" data-choice-num="2" placeholder="보기 2">
+                        <div class="option-item-2" d-flex align-items-center mb-2">
+                            <div id="choice-editor-${number}-2" 
+                                class="choice-editor form-control option-input" 
+                                data-choice-num="2"
+                                data-choice-id="${number}-2" 
+                                contenteditable="true" 
+                                style="background: #fff;"
+                            ></div>
                             <button type="button" class="btn btn-danger btn-sm btn-remove-option">
                                 <i class="fas fa-times"></i>
                             </button>
@@ -625,6 +637,7 @@ const addQuestion = () => {
     const newQuestionHtml = createQuestionHml(questionCounter)
 
     questionContainer.insertAdjacentHTML('beforeend', newQuestionHtml)
+    window.edit_common.initChoiceEditors()
 }
 
 // 문항 삭제 함수
@@ -847,8 +860,14 @@ const addOption = (questionItem) => {
         let output = ''
         output += 
         `
-            <div class="option-item-${nextCount}">
-                <input type="text" class="form-control option-input" data-choice-num="${nextCount}" placeholder="보기 ${nextCount}">
+            <div class="option-item-${nextCount}" d-flex align-items-center mb-2">
+                <div id="choice-editor-${questionNum}-${nextCount}"
+                    class="choice-editor form-control option-input"
+                    data-choice-num="${nextCount}" 
+                    data-choice-id="${questionNum}-${nextCount}"
+                    contenteditable="true"
+                    style="background: #fff;"
+                ></div>
                 <button type="button" class="btn btn-danger btn-sm btn-remove-option">
                     <i class="fas fa-times"></i>
                 </button>
@@ -1001,17 +1020,18 @@ const saveExam = () => {
 
         // 5. 선택지
         let choices = []
-        const optionInputs = card.querySelectorAll("input.option-input")
-        const choiceLabels = ['①', '②', '③', '④', '⑤']
 
-        for(const input of optionInputs){
-            const choiceContent = input ? input.value.trim() : ''
-            if(!choiceContent){
+        const divs = card.querySelectorAll(".choice-editor")
+        const choiceLabels = ['①', '②', '③', '④', '⑤']
+        for(const div of divs){
+            const choiceId = div.dataset.choiceId
+            const choiceContent = window.edit_common.getChoiceContent(choiceId)
+            if(!choiceContent || choiceContent.trim() === ''){
                 alert(`${questionNum}번 문항의 선택지를 입력해주세요.`)
                 return
             }
 
-            const choiceNum = parseInt(input.getAttribute("data-choice-num"), 10)
+            const choiceNum = parseInt(div.getAttribute("data-choice-num"), 10)
 
             choices.push({
                 choiceNum: choiceNum,
@@ -1019,6 +1039,7 @@ const saveExam = () => {
                 choiceLabel: choiceLabels[choiceNum - 1]
             })
         }
+
         questionObj.questionChoices = choices
 
         // 6. 정답

--- a/src/main/webapp/resources/js/admin_exam_edit_page.js
+++ b/src/main/webapp/resources/js/admin_exam_edit_page.js
@@ -48,6 +48,7 @@ const ExamEditor = {
             console.error("데이터 파싱 중 오류 발생: ", error)
         }
 
+        this.initChoiceEditors()
     },
 
     getData(){
@@ -55,11 +56,11 @@ const ExamEditor = {
     },
 
     getEditorContent(qNum){
-        const quill = ExamEditor.editors[qNum]
+        const quill = this.editors[qNum]
         if(quill){
             return quill.root.innerHTML
         }
-        return
+        return ''
     },
 
     initSection(category, id, passageData){
@@ -265,6 +266,75 @@ const ExamEditor = {
         } catch (error) {
             console.error("Quill 초기화 중 치명적 오류 발생:", error)
         }
+    },
+
+    initChoiceEditors(){
+        const choiceElements = document.querySelectorAll(".choice-editor")
+        choiceElements.forEach((el) => {
+            if (el.classList.contains('ql-container')) return
+
+            const choiceId = el.dataset.choiceId
+            const editorId = `#choice-editor-${choiceId}`
+            const initialData = el.innerHTML.trim() // 초기 데이터 (이미 HTML로 렌더링된 상태)
+
+            const quill = new Quill(editorId, {
+                theme: 'bubble', // 드래그 시 툴바가 뜨는 버블 테마
+                modules: {
+                    toolbar: ['bold', 'italic', 'underline', 'strike', 'clean'] // 최소 기능
+                },
+                placeholder: '보기를 입력하세요.'
+            })
+
+            // 텍스트 에디터에 초기값 주입
+            if(initialData){
+                quill.root.innerHTML = initialData
+            }
+
+            // 전역 객체에 저장
+            this.editors[`choice-${choiceId}`] = quill
+
+            // 드래그 감지 이벤트리스너
+            this._choiceEventHandler(quill, el)
+        })   
+    },
+
+    _choiceEventHandler(quill, el){
+        const tooltip = el.querySelector(".ql-tooltip")
+
+        // 1. 드래그 시작 전
+        el.addEventListener('mousedown', (e) => {
+            if (tooltip && tooltip.contains(e.target)) return
+
+            if (tooltip) {
+                tooltip.classList.add('ql-hidden')
+            }
+        })
+
+        // 2. 툴바 내부 클릭 시 이벤트 전파 차단
+        if (tooltip) {
+            tooltip.addEventListener('mousedown', (e) => {
+                e.preventDefault()
+                e.stopPropagation()
+            });
+        }
+
+        // 3. 마우스 뗄 때
+        el.addEventListener('mouseup', (e) => {
+            if (tooltip && tooltip.contains(e.target)) return
+
+            setTimeout(() => {
+                const range = quill.getSelection()
+                if (range && range.length > 0 && tooltip) {
+                    tooltip.classList.remove('ql-hidden')
+                }
+            }, 50)
+        })
+
+    },
+
+    getChoiceContent(choiceId){
+        const quill = this.editors[`choice-${choiceId}`]
+        return quill ? quill.root.innerHTML : '' 
     },
 
     // Quill 에디터는 이미지 업로드 시 이미지를 서버로 전송하지 않고 브라우저 내에 텍스트로 변환하여 저장함
@@ -530,23 +600,22 @@ const QuestionEditHandler = {
     },
 
     _collectChoices(optionsGroup){
-        const inputs = optionsGroup.querySelectorAll("input.option-input")
-
-        for(const input of inputs){
-            const choiceText = input.value.trim()
-            if(!choiceText){
+        const divs = optionsGroup.querySelectorAll(".choice-editor")
+        for(const div of divs){
+            const choiceId = div.dataset.choiceId
+            const choiceText = ExamEditor.getChoiceContent(choiceId)
+            if(!choiceText || choiceText.trim() === ''){
                 alert('선택지를 작성해주세요.')
-                input.focus()
+                div.focus()
                 return false
             }
-            
-            const choiceId = input.dataset.choiceId
+
             const choice = this.questionObj.questionChoices.find(c => c.choiceId == choiceId)
             if(!choice){
                 alert('새로고침 후 다시 시도해주세요.')
                 return false
-            } 
-            
+            }
+
             choice.choiceText = choiceText
         }
 
@@ -616,5 +685,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 window.edit_common = {
     renderPassageInput: ExamEditor.renderPassageInput.bind(ExamEditor),
-    bindPassageEvents: ExamEditor.bindPassageEvents.bind(ExamEditor)
+    bindPassageEvents: ExamEditor.bindPassageEvents.bind(ExamEditor),
+    initChoiceEditors: ExamEditor.initChoiceEditors.bind(ExamEditor),
+    getChoiceContent: ExamEditor.getChoiceContent.bind(ExamEditor)
 }


### PR DESCRIPTION
## 📌 변경 사항
- **선택지 입력 컴포넌트 교체:** 기존 단순 `input` 필드를 `Quill.js (Bubble Theme)` 리치 텍스트 에디터로 전면 교체
- **커스텀 툴바 제어:** 드래그 시 볼드, 이탤릭, 밑줄 등 핵심 서식 도구가 나타나도록 설정
- **수동 이벤트 핸들러 구현:** Quill 내부 버그 및 포커스 유실 문제를 해결하기 위해 마우스 기반의 직접 제어 로직을 추가
- **데이터 취합 모듈화:** `getChoiceContent()` 함수를 통해 에디터 내 HTML 데이터를 안전하게 수집하도록 개선

## 🛠️ 수정한 이유
- 기존 `input` 기반 문항 입력 방식은 텍스트 서식을 지원하지 않아 일부 문항 유형 출제가 어려워 리치 텍스트 에디터를 도입
- **Quill내부 버그 대응:** 드래그 시 자동으로 사라져야 할 `.ql-hidden` 클래스가 유지되는 버그가 확인되어, 이를 마우스 이벤트를 통해 직접 제어하도록 구현

## 🔍 주요 변경 파일
- exam_create_page.jsp
- exam_edit_page.jsp
- admin_exam_create_page.js
- admin_exam_edit_page.js

## ✅ 테스트 내용
- [x] 문항/보기 추가 시 신규 에디터가 정상적으로 로드되는지 확인
- [x] 텍스트 드래그 시 툴바가 정확한 위치(선택 영역 중앙 상단)에 표시되는지 확인
- [x] 저장 시 에디터 내 HTML 태그가 DB 전송 데이터에 포함되는지 확인

## 🔗 관련 이슈
closes #40 
