### PR TITLE
[FEAT] 시험지 수정 페이지 내 선택지(Choice) 동적 추가 기능 구현 및 검증 로직 강화

### DIFF
--- a/src/main/java/com/my/ex/dto/request/ExamCreateRequestDto.java
+++ b/src/main/java/com/my/ex/dto/request/ExamCreateRequestDto.java
@@ -1,11 +1,10 @@
 package com.my.ex.dto.request;
 
-import java.util.List;
-import java.util.Map;
-
+import lombok.Data;
 import org.springframework.web.multipart.MultipartFile;
 
-import lombok.Data;
+import java.util.List;
+import java.util.Map;
 
 @Data
 public class ExamCreateRequestDto {
@@ -65,6 +64,8 @@ public class ExamCreateRequestDto {
 			private int choiceNum;
 			private String choiceText;
 			private String choiceLabel;
+
+			private String tempId; // 선택지 임시 id(ex."1-1")
 		}
 		
 		@Data

--- a/src/main/java/com/my/ex/service/ExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/ExamSelectionService.java
@@ -480,7 +480,10 @@ public class ExamSelectionService implements IExamSelectionService {
 	@Transactional
 	public void updateExamByForm(ExamCreateRequestDto request) {
 		updateQuestion(request.getExamInfo(), request.getQuestion(), request.getFileMap());
-		updateQuestionChoices(request.getQuestion().getQuestionChoices());
+		updateQuestionChoices(
+				request.getExamInfo().getExamId(),
+				request.getQuestion().getQuestionChoices(),
+				request.getQuestion().getQuestionId());
 		answerService.updateQuestionAnswer(
 				request.getQuestion().getQuestionId(),
 				request.getQuestion().getQuestionAnswer(),
@@ -576,10 +579,29 @@ public class ExamSelectionService implements IExamSelectionService {
 		dao.updateQuestion(dto);
 	}
 	
-	private void updateQuestionChoices(List<QuestionChoice> choice) {
+	private void updateQuestionChoices(Integer examId, List<QuestionChoice> choice, Integer questionId) {
 		for(QuestionChoice c : choice) {
-			ExamChoiceDto dto = new ExamChoiceDto(c.getChoiceId(), c.getChoiceText());
-			dao.updateQuestionChoices(dto);
+			String tempId = c.getTempId();
+
+			if(tempId != null && tempId.contains("-") && c.getChoiceId() == 0){
+				String[] label = {"①", "②", "③", "④", "⑤"};
+				ExamChoiceDto dto = new ExamChoiceDto();
+
+				int idx = tempId.indexOf("-");
+				int choiceNum = Integer.valueOf(tempId.substring(idx + 1));
+
+				dto.setExamId(examId);
+				dto.setQuestionId(questionId);
+				dto.setChoiceLabel(label[choiceNum - 1]);
+				dto.setChoiceText(c.getChoiceText());
+				dto.setChoiceImage(null);
+				dto.setChoiceNum(choiceNum);
+
+				dao.saveParsedChoiceInfo(dto);
+			} else {
+				ExamChoiceDto dto = new ExamChoiceDto(c.getChoiceId(), c.getChoiceText());
+				dao.updateQuestionChoices(dto);
+			}
 		}
 	}
 	

--- a/src/main/webapp/WEB-INF/views/admin/exam_edit_page.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/exam_edit_page.jsp
@@ -115,9 +115,9 @@
 									</div>	
 								</c:forEach>
 							</div>
-	<!-- 	                    <button type="button" class="btn btn-sm btn-outline-primary btn-add-option"> -->
-	<!-- 	                        + 보기 추가 -->
-	<!-- 	                    </button> -->
+	 	                    <button type="button" class="btn btn-sm btn-outline-primary btn-add-option">
+	 	                        + 보기 추가
+	 	                    </button>
 						</div>
 		
 						<div class="form-group answer-group">

--- a/src/main/webapp/resources/css/admin_exam_create_page.css
+++ b/src/main/webapp/resources/css/admin_exam_create_page.css
@@ -220,7 +220,8 @@ input::placeholder {
     transition: border-color 0.2s;
 }
 
-.form-control:focus {
+.form-control:focus,
+.choice-editor.ql-container:focus-within {
     border-color: #5D9CEC;
     box-shadow: 0 0 0 3px rgba(93, 156, 236, 0.1);
     outline: none;

--- a/src/main/webapp/resources/js/admin_exam_edit_page.js
+++ b/src/main/webapp/resources/js/admin_exam_edit_page.js
@@ -482,6 +482,7 @@ const QuestionEditHandler = {
             this.questionObj.questionChoices = choices.map(c => ({
                 choiceId: c.choiceId,
                 choiceText: c.choiceText,
+                tempId: null
                 // choiceNum: c.choiceNum,
                 // choiceLabel: c.choiceLabel
             }))
@@ -582,7 +583,6 @@ const QuestionEditHandler = {
             this.questionObj.useCommonPassage = 'N'
             this.questionObj.commonPassage = null
         }
-
         return true
     },
 
@@ -601,22 +601,38 @@ const QuestionEditHandler = {
 
     _collectChoices(optionsGroup){
         const divs = optionsGroup.querySelectorAll(".choice-editor")
+        if(divs.length < 4){
+            alert(`현재 선택지가 ${divs.length}개입니다. 시험 문항은 최소 4개 이상의 선택지가 필요합니다.`)
+            return false
+        }
+
         for(const div of divs){
             const choiceId = div.dataset.choiceId
             const choiceText = ExamEditor.getChoiceContent(choiceId)
-            if(!choiceText || choiceText.trim() === ''){
+            
+            // HTML 태그를 모두 제거하고 순수 텍스트만 남김
+            const plainText = choiceText.replace(/<[^>]*>?/gm, '').trim()
+            
+            if(!plainText || plainText.trim() === ''){
                 alert('선택지를 작성해주세요.')
                 div.focus()
                 return false
-            }
+            } 
 
-            const choice = this.questionObj.questionChoices.find(c => c.choiceId == choiceId)
-            if(!choice){
-                alert('새로고침 후 다시 시도해주세요.')
-                return false
+            const existingChoice = this.questionObj.questionChoices.find(c => c.choiceId == choiceId)
+            if(existingChoice){
+                // 기존에 있던 선택지는 텍스트만 업데이트
+                existingChoice.choiceText = choiceText
+            } else {
+                // 새로 추가된 선택지인 경우 새 객체 생성
+                this.questionObj.questionChoices.push(
+                    {
+                        choiceId: null,
+                        choiceText: choiceText,
+                        tempId: choiceId
+                    }
+                )
             }
-
-            choice.choiceText = choiceText
         }
 
         return true


### PR DESCRIPTION
## 📌 변경 사항
- **선택지(Choice) 동적 추가 UI 구현:** 수정 페이지 내에서 부족한 선택지를 실시간으로 추가할 수 있는 '보기 추가' 버튼 및 에디터 생성 로직을 추가
- **데이터 저장 분기 처리 로직 도입:** `choiceId`가 없는 신규 선택지에 대해 `tempId`(1-1 등)를 식별하여, 서버단에서 `INSERT`와 `UPDATE`를 구분해 처리하도록 확장
- **Quill 에디터 검증 로직 강화:** 에디터 내부에 잔여 `HTML` 태그만 있는 경우를 '빈 값'으로 간주하기 위해 Plain Text 기반의 유효성 검사를 적용
- **UI/UX 개선:** 선택지 에디터 포커스 시 테두리 하이라이트 스타일(`:focus-within`)을 적용하여 사용자 피드백을 강화

## 🛠️ 수정한 이유
- **데이터 완전성 보완:** PDF 파싱 오류로 인해 일부 문항의 선택지가 누락된 경우, 관리자가 시스템 내에서 즉시 수정 및 추가할 수 있는 창구가 필요했음
- **데이터 정합성 유지:** 신규 데이터 추가 시 기존 데이터와 충돌하지 않도록 임시 ID 체계를 활용한 서버 로직 보완이 필요했음
- **입력 오류 방지:** 단순 `trim()` 체크로 잡히지 않는 리치 텍스트 에디터의 특성상, 보다 정밀한 빈 값 검증 로직이 요구됨

## 🔍 주요 변경 파일
- ExamSelectionService.java
- ExamCreateRequestDto.java
- exam_edit_page.jsp
- admin_exam_edit_page.js
- admin_exam_create_page.css

## ✅ 테스트 내용
- [x] '보기 추가' 버튼 클릭 시 신규 에디터가 정상적으로 생성되는지 확인
- [x] 신규 추가된 보기가 DB에 `INSERT` 되고, 기존 보기는 `UPDATE` 되는지 확인
- [x] 선택지가 4개 미만일 경우 저장 차단 및 안내 문구 노출 확인
- [x] 내용이 비어있는(태그만 있는) 선택지 저장 시 포커스 및 경고 창 작동 확인

## 🔗 관련 이슈
closes #45 
