### PR TITLE
[BUG] GCS 저장소 활성화 시 이미지 경로 생성 로직 오류 수정

### DIFF
--- a/src/main/java/com/my/ex/controller/ExamSelectionController.java
+++ b/src/main/java/com/my/ex/controller/ExamSelectionController.java
@@ -7,28 +7,27 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.my.ex.config.EnvironmentConfig;
 import com.my.ex.dto.*;
 import com.my.ex.dto.request.ExamCreateRequestDto;
-import com.my.ex.dto.request.ExamSearchDto;
 import com.my.ex.dto.request.ExamCreateRequestDto.CreateExamInfo;
 import com.my.ex.dto.request.ExamCreateRequestDto.Question;
+import com.my.ex.dto.request.ExamSearchDto;
 import com.my.ex.dto.request.MoveExamsToFolderDto;
-import com.my.ex.dto.response.ChartStatisticsDto;
-import com.my.ex.dto.response.ExamInfoGroup;
-import com.my.ex.dto.response.ExamPageDto;
-import com.my.ex.dto.response.ExamPdfPreview;
-import com.my.ex.dto.response.ExamTitleDto;
+import com.my.ex.dto.response.*;
 import com.my.ex.parser.geomjeong.parse.exam.GeomjeongExamParser;
 import com.my.ex.service.IExamAnswerService;
 import com.my.ex.service.IExamSelectionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -174,22 +173,35 @@ public class ExamSelectionController {
 	
 	@GetMapping("/getExamImagePath")
 	@ResponseBody
-	public Resource getExamImagePath(
+	public Object getExamImagePath(
 		@RequestParam(required = false, defaultValue = "") String examType,
 		@RequestParam(required = false, defaultValue = "") String examRound,
 		@RequestParam(required = false, defaultValue = "") String examSubject,
 		@RequestParam String filename)
 	{
-		Path filePath;
 		String baseDir = config.getImageUploadPath();
-		
-		if(examType.isEmpty() && examRound.isEmpty() && examSubject.isEmpty()) {
-			filePath = Paths.get(baseDir, "temp", filename);
-		} else {
-			filePath = Paths.get(baseDir, examType, examRound, examSubject, filename);
+		boolean isTemp = examType.isEmpty() && examRound.isEmpty() && examSubject.isEmpty();
+
+		// 1. GCS 환경일 경우: 주소 반환
+		if(baseDir != null && baseDir.startsWith("http")){
+			String fullUrl = isTemp ?
+					String.join("/", baseDir, "temp", filename) :
+					String.join("/", baseDir, examType, examRound, examSubject, filename);
+
+			URI encodedUri = UriComponentsBuilder.fromHttpUrl(fullUrl)
+					.build()
+					.encode()
+					.toUri();
+			return ResponseEntity.status(HttpStatus.FOUND)
+					.location(encodedUri)
+					.build();
 		}
-		
-		// C:\server_program\project\testmate\images\2025년도 제1회\국어
+
+		// 2. 로컬/운영 환경일 경우: 파일 리소스 반환
+		Path filePath = isTemp ?
+				Paths.get(baseDir, "temp", filename) :
+				Paths.get(baseDir, examType, examRound, examSubject, filename);
+
 		File file = filePath.toFile();
 		if (file.exists()) {
 			return new FileSystemResource(file); // file자체를 보내는 것은 X, HTTP 본문 응답으로 자동 변환해주는 API(FileSystemResource())를 이용해서 보내야 함


### PR DESCRIPTION
## 📌 변경 사항
- **GCS 환경 전용 이미지 경로 로직 추가**: 저장소 설정(`baseDir`)이 `http`로 시작할 경우, 파일 시스템이 아닌 웹 URL로 처리하도록 분기 로직 구현
- **URL 인코딩 적용**: `UriComponentsBuilder`를 도입하여 경로 내 한글 및 공백 문자를 RFC 3986 표준에 맞게 인코딩 처리
- **302 리다이렉트 구현**: GCS 모드일 때 서버가 직접 파일을 읽지 않고, `ResponseEntity`를 통해 클라우드 저장소 주소로 브라우저를 유도하도록 수정
- **로직 격리(Early Return)**: GCS 처리가 완료되면 즉시 반환하여 하단의 로컬 파일 참조 코드(`Paths.get`)가 실행되지 않도록 구조 개선

## 🛠️ 수정한 이유
- **InvalidPathException 해결**: GCS URL(`https://...`)을 파일 시스템 API인 `Paths.get`에 전달할 때 발생하는 경로 포맷 오류 수정
- **한글 파일명 접근성 확보**: 경로에 포함된 한글 및 공백으로 인해 발생하는 `URISyntaxException` 및 이미지 엑박 현상 해결
- **환경별 가용성 증대**: `activeStorage` 설정값에 따라 로컬 디렉터리와 GCS 클라우드 자원을 안전하게 스위칭할 수 있는 구조 필요

## 🔍 주요 변경 파일
- ExamSelectionController.java

## ✅ 테스트 내용
- [x] GCS 활성화 시 한글 파일명 이미지 정상 출력 확인
- [x] Local 환경에서 기존 디렉터리 참조 기능 동작 확인
- [x] 리다이렉트 시 브라우저 네트워크 탭 Status 302 확인

## 🔗 관련 이슈
closes #47 