### PR TITLE
[BUG] 폴더별 시험지 개수 조회 시 삭제된 시험지가 포함되는 오류 수정

### DIFF
--- a/src/main/resources/mappers/Adminmapper.xml
+++ b/src/main/resources/mappers/Adminmapper.xml
@@ -60,6 +60,7 @@
 			SELECT count(*)
 			  FROM exam_info i
 			 WHERE f.folder_id = i.folder_id
+			   AND i.isdeleted = 'N'
 		) AS examCount
 		  FROM exam_folder f
 		 WHERE f.folder_id != #{excludeFolderId}


### PR DESCRIPTION
## 📌 변경 사항
- **시험지 수량 산출 쿼리 보완**: `EXAM_FOLDER` 조회 시 각 폴더에 속한 시험지 개수를 계산하는 서브쿼리에 `isDeleted = 'N'` 조건을 추가

## 🛠️ 수정한 이유
- **데이터 정합성 결함 해결**: 기존 로직은 삭제된 시험지(`isDeleted = 'Y'`)까지 모두 카운트하여 사용자에게 잘못된 수량을 노출하고 있었음. 이를 수정하여 실제 사용 가능한 시험지 수만 정확히 표시하도록 개선

## 🔍 주요 변경 파일
- Adminmapper.xml

## ✅ 테스트 내용
- [x] 시험지 삭제 시 폴더 목록 화면에서 `examCount`가 즉각 반영되는지 확인
- [x] 삭제된 시험지가 포함된 폴더의 카운트와 실제 문항 리스트의 개수가 일치하는지 확인
- [x] 기존 필터 조건(`folder_id != 1` 및 폴더 자체 삭제 여부)이 유지되는지 확인

## 🔗 관련 이슈
closes #49 