### PR TITLE
[BUG] 정답지가 포함된 시험 종류가 메인 페이지에서 누락되는 오류 수정

### DIFF
--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -16,7 +16,6 @@
 		         FROM exam_info paper
 		         JOIN exam_info ans ON paper.exam_round = ans.exam_round 
 		                           AND paper.exam_subject = ans.exam_subject
-		                           AND paper.folder_id = ans.folder_id
 		         JOIN exam_type ans_type ON ans.exam_type_id = ans_type.exam_type_id
 		        WHERE paper.isdeleted = 'N'
 		          AND ans.isdeleted = 'N'


### PR DESCRIPTION
## 📌 변경 사항
- **시험 종류 조회 쿼리(`getExamTypes`) 보완**: 시험지와 정답지 매칭 조건에서 `folder_id` 일치 여부 체크를 제거

## 🛠️ 수정한 이유
- **데이터 노출 누락 해결**: 시험지와 정답지가 서로 다른 폴더에 저장되어 있을 경우, 기존의 폴더 일치 조건 때문에 메인 페이지에서 해당 시험 종류가 조회되지 않는 문제가 있었음
- **유연한 데이터 매칭**: 폴더 위치와 관계없이 '회차'와 '과목'이 일치하는 정답지가 존재한다면 사용자에게 올바른 시험 정보를 제공하도록 로직을 개선

## 🔍 주요 변경 파일
- ExamSelectionmapper.xml

## ✅ 테스트 내용
- [x] 시험지와 정답지의 `folder_id`가 서로 달라도 메인 페이지에 시험 종류가 정상 노출되는지 확인
- [x] 메인 쿼리의 `NOT LIKE '%Answer'` 필터를 통해 문제지 타입만 정확히 골라내는지 확인

## 🔗 관련 이슈
closes #51 