### PR TITLE
[FEAT] 시험지 목록 무한 스크롤 기능 구현

### DIFF
--- a/src/main/java/com/my/ex/controller/AdminController.java
+++ b/src/main/java/com/my/ex/controller/AdminController.java
@@ -1,33 +1,20 @@
 package com.my.ex.controller;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-
-import com.my.ex.dto.ExamAnswerDto;
-import com.my.ex.dto.ExamChoiceDto;
-import com.my.ex.dto.ExamFolderDto;
-import com.my.ex.dto.ExamQuestionDto;
-import com.my.ex.dto.ExamTypeDto;
+import com.my.ex.dto.*;
 import com.my.ex.dto.request.MoveExamsToFolderDto;
 import com.my.ex.dto.response.ExamPageDto;
 import com.my.ex.dto.response.ExamTitleDto;
 import com.my.ex.service.IAdminService;
 import com.my.ex.service.IExamAnswerService;
 import com.my.ex.service.IExamSelectionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 // 관리자 페이지에서 수행하는 관리 영역
 @RequestMapping("/admin")
@@ -109,8 +96,11 @@ public class AdminController {
 	 */
 	@GetMapping("/examList")
 	@ResponseBody
-	public List<ExamTitleDto> getExamList(@RequestParam int folderId){
-		return examService.getAllExamTitlesByFolderId(folderId);
+	public List<ExamTitleDto> getExamList(
+			@RequestParam int folderId,
+			@RequestParam(required = false, defaultValue = "1") int page){
+
+		return examService.getAllExamTitlesByFolderId(folderId, page);
 	}
 
 	/**

--- a/src/main/java/com/my/ex/dao/ExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/ExamSelectionDao.java
@@ -1,18 +1,17 @@
 package com.my.ex.dao;
 
-import java.util.List;
-import java.util.Map;
-
-import org.apache.ibatis.session.SqlSession;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Repository;
-
 import com.my.ex.dto.ExamChoiceDto;
 import com.my.ex.dto.ExamInfoDto;
 import com.my.ex.dto.ExamQuestionDto;
 import com.my.ex.dto.ExamTypeDto;
 import com.my.ex.dto.request.ExamSearchDto;
 import com.my.ex.dto.response.ExamTitleDto;
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
 
 @Repository
 public class ExamSelectionDao implements IExamSelectionDao {
@@ -48,8 +47,8 @@ public class ExamSelectionDao implements IExamSelectionDao {
 	}
 	
 	@Override
-	public List<ExamTitleDto> getAllExamTitlesByFolderId(int folderId) {
-		return session.selectList(NAMESPACE + "getAllExamTitlesByFolderId", folderId);
+	public List<ExamTitleDto> getAllExamTitlesByFolderId(Map<String, Object> map) {
+		return session.selectList(NAMESPACE + "getAllExamTitlesByFolderId", map);
 	}
 	
 	@Override

--- a/src/main/java/com/my/ex/dao/IExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/IExamSelectionDao.java
@@ -16,7 +16,7 @@ public interface IExamSelectionDao {
 	List<ExamTypeDto> getExamPaperTypes();
 	List<String> getExamRounds(String examTypeCode);
 	List<String> getSubjectsByExamRound(Map<String, String> map);
-	List<ExamTitleDto> getAllExamTitlesByFolderId(int folderId);
+	List<ExamTitleDto> getAllExamTitlesByFolderId(Map<String, Object> map);
 	int checkExistingExamInfo(ExamInfoDto examInfo);
 	void saveParsedExamInfo(ExamInfoDto examInfo);
 	void saveParsedQuestionInfo(Map<String, Object> question);

--- a/src/main/java/com/my/ex/service/ExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/ExamSelectionService.java
@@ -38,27 +38,27 @@ public class ExamSelectionService implements IExamSelectionService {
 
 	@Autowired
 	private ExamSelectionDao dao;
-	
+
 	@Autowired
 	private EnvironmentConfig config;
-	
+
 	@Autowired
 	private UploadedGeomjeongPdfTextExtractor extractor;
-	
+
 	@Autowired
 	private GeomjeongPdfTextNormalizer normalizer;
-	
+
 	@Autowired
 	private GeomjeongExamParser gedExamParser;
-	
+
 	@Autowired
 	private ExamAnswerService answerService;
-	
+
 	@Override
 	public List<ExamTypeDto> getExamTypes() {
 		return dao.getExamTypes();
 	}
-	
+
 	@Override
 	public List<ExamTypeDto> getAllExamTypes() {
 		return dao.getAllExamTypes();
@@ -79,13 +79,24 @@ public class ExamSelectionService implements IExamSelectionService {
 		Map<String, String> map = new HashMap<>();
 		map.put("examTypeCode", examTypeCode);
 		map.put("examRound", examRound);
-		
+
 		return dao.getSubjectsByExamRound(map);
 	}
-	
+
 	@Override
-	public List<ExamTitleDto> getAllExamTitlesByFolderId(int folderId) {
-		return dao.getAllExamTitlesByFolderId(folderId);
+	public List<ExamTitleDto> getAllExamTitlesByFolderId(int folderId, int page) {
+		// 한 페이지당 보여줄 게시글 수
+		final int COUNT = 9;
+
+		int endRow = page * COUNT;
+		int startRow = endRow - (COUNT - 1);
+
+		Map<String, Object> map = new HashMap<>();
+		map.put("folderId", folderId);
+		map.put("startRow", startRow);
+		map.put("endRow", endRow);
+
+		return dao.getAllExamTitlesByFolderId(map);
 	}
 
 	@Override
@@ -97,20 +108,20 @@ public class ExamSelectionService implements IExamSelectionService {
 		Integer subjectId = dao.findSubjectIdByName(map);
 		if(subjectId == null) throw new RuntimeException("subjectId가 null입니다. 과목명을 확인하세요.");
 		examInfo.setSubjectId(subjectId);
-		
+
 		// 중복 시험 정보 확인
 		if(dao.checkExistingExamInfo(examInfo) > 0) return false;
-		
+
 		// 폴더 id 저장
 		if(examInfo.getFolderId() == null) {
 			examInfo.setFolderId(1);
 		}
-		
+
 		// 시험 정보 저장
 		dao.saveParsedExamInfo(examInfo); // 시험 정보 저장 후 examId으로 설정됨
 		Integer examId = (Integer)examInfo.getExamId(); // DB 삽입 후 주입된 examId 가져옴
 		if(examId == null || examId <= 0) throw new RuntimeException();
-		
+
 		// 시험 문제 저장
 		List<ExamAnswerDto> answersList = new ArrayList<>();
 		boolean hasAnswerData = false; // 정답 데이터 존재 여부
@@ -119,18 +130,18 @@ public class ExamSelectionService implements IExamSelectionService {
 			dao.saveParsedQuestionInfo(question); // 문제 저장 후 questionId 받아옴
 			Integer questionId = (Integer)question.get("questionId"); // DB 삽입 후 주입된 questionId
 			if(questionId == null || questionId <= 0) throw new RuntimeException();
-			
+
 			// 시험 선택지 저장
 			@SuppressWarnings("unchecked")
 			List<ExamChoiceDto> options = (List<ExamChoiceDto>) question.get("options");
 			for(ExamChoiceDto choiceDto : options) {
 				choiceDto.setExamId(examId);
 				choiceDto.setQuestionId(questionId);
-				
+
 				int insertResult = dao.saveParsedChoiceInfo(choiceDto);
 				if(insertResult <= 0) throw new RuntimeException();
 			}
-			
+
 			// 시험 정답지 저장
 			Object answerObj = question.get("answer");
 			if(answerObj != null) {
@@ -141,16 +152,16 @@ public class ExamSelectionService implements IExamSelectionService {
 				hasAnswerData = true;
 			}
 		}
-		
+
 		// 정답 데이터가 있는 경우에만 호출
 		if(hasAnswerData) {
 			String examTypeCodeWithAnswer = answerService.
-					examTypeCodeWithAnswer(examInfo.getExamTypeEng()); 
+					examTypeCodeWithAnswer(examInfo.getExamTypeEng());
 			int answerExamTypeId = findTypeIdByCode(examTypeCodeWithAnswer);
 			examInfo.setExamTypeId(answerExamTypeId);
 			answerService.saveParsedAnswerData(examInfo, answersList);
 		}
-		
+
 		return true;
 	}
 
@@ -158,17 +169,17 @@ public class ExamSelectionService implements IExamSelectionService {
 	public String getExamtypename(String examType) {
 		return dao.getExamtypename(examType);
 	}
-	
+
 	@Override
 	public List<ExamQuestionDto> getExamQuestions(String examType, String examRound, String examSubject) {
 		Map<String, Object> map = new HashMap<>();
 		map.put("examType", examType);
 		map.put("examRound", examRound);
 		map.put("examSubject", examSubject);
-		
+
 		return dao.getExamQuestions(map);
 	}
-	
+
 	@Override
 	public List<ExamQuestionDto> getExamQuestionsByExamId(int examId) {
 		return dao.getExamQuestionsByExamId(examId);
@@ -180,20 +191,20 @@ public class ExamSelectionService implements IExamSelectionService {
 		map.put("examType", examType);
 		map.put("examRound", examRound);
 		map.put("examSubject", examSubject);
-		
+
 		List<ExamQuestionDto> questionDto = dao.getCommonPassageInfo(map);
 		Set<ExamPageDto.ExamCommonpassageDto> distinctPassageSet = new HashSet<>();
-		
+
 		for(ExamQuestionDto dto: questionDto) {
 			ExamPageDto.ExamCommonpassageDto commonpassageDto = new ExamPageDto.ExamCommonpassageDto();
 			String scope = dto.getPassageScope(); // 11~13
-			
+
 			commonpassageDto.setCommonPassageStartNum(Integer.parseInt(scope.split("~")[0])); // 11
 			commonpassageDto.setCommonPassageEndNum(Integer.parseInt(scope.split("~")[1])); // 13
 			commonpassageDto.setCommonPassageText(dto.getCommonPassage()); // 공통 지문
 			distinctPassageSet.add(commonpassageDto);
 		}
-		
+
 		return distinctPassageSet;
 	}
 
@@ -220,21 +231,21 @@ public class ExamSelectionService implements IExamSelectionService {
 	@Override
 	public boolean saveExamByForm(ExamCreateRequestDto request) {
 		ParsedExamData data = buildParsedExamData(request);
-		
+
 		return saveParsedExamData(data.getExamInfo(), data.getNewList());
 	}
 
 	/**
 	 * ExamCreateRequestDto(요청 데이터)를 DB 저장용 구조로 변환하고
 	 * ExamInfoDto와 문제 리스트(Map 포함)를 조립하여 ParsedExamData로 반환.
-	 * 
+	 *
 	 * 관리자가 PDF 업로드 또는 직접 작성한 시험지를 저장할 때
 	 * saveParsedExamData() 호출 전에 사용됨.
 	 */
 	@Override
 	public ParsedExamData buildParsedExamData(ExamCreateRequestDto request) {
 		// 시험 코드로 부터 시험 종류 조회(middle-geomjeong → 중졸 검정고시)
-		
+
 		ExamInfoDto examInfo = new ExamInfoDto();
 		String subject = request.getExamInfo().getSubject();
 		String round = request.getExamInfo().getRound();
@@ -247,17 +258,17 @@ public class ExamSelectionService implements IExamSelectionService {
 		examInfo.setExamTypeId(examTypeId);
 		examInfo.setFolderId(request.getExamInfo().getFolderId());
 		examInfo.setExamTypeEng(engType);
-		
+
 		List<Question> questions = request.getQuestions();
 		List<Map<String, Object>> newList = new ArrayList<>();
 		for(Question q : questions) {
 			Map<String, Object> map = new HashMap<>();
 			// 문제번호
 			map.put("questionNum", q.getQuestionNum());
-			
+
 			// 문제
 			map.put("questionText", q.getQuestionText());
-			
+
 			// 개별지문
 			map.put("useIndividualPassage", q.getUseIndividualPassage());
 			if(q.getUseIndividualPassage() == 'Y') {
@@ -269,7 +280,7 @@ public class ExamSelectionService implements IExamSelectionService {
 					// 파일이름 생성
 					String filename = q.getIndividualPassage().getContent().trim().replace(" ", "_");
 					String uniqueFilename = UUID.randomUUID().toString() + "_" + filename;
-				
+
 					// 파일 저장
 	                String fileKey = q.getIndividualPassage().getFileKey();
 	                MultipartFile file = request.getFileMap().get(fileKey);
@@ -278,15 +289,15 @@ public class ExamSelectionService implements IExamSelectionService {
 				} else if(q.getIndividualPassage().getType().equals("text")) {
 					// html 코드에 이미지 태그가 있으면 src 속성을 파일 이름으로 수정
 					String processHtml = processHtmlEmbeddedImages(
-							q.getIndividualPassage().getContent(), 
-							typename, 
-							round, 
+							q.getIndividualPassage().getContent(),
+							typename,
+							round,
 							subject
 					);
 					map.put("individualPassage", processHtml);
 				}
-			} 
-			
+			}
+
 			// 공통지문
 			map.put("useCommonPassage", q.getUseCommonPassage());
 			if(q.getUseCommonPassage() == 'Y') {
@@ -301,17 +312,17 @@ public class ExamSelectionService implements IExamSelectionService {
 					String uniqueFilename = UUID.randomUUID().toString() + "_" + filename;
 					map.put("commonPassage", uniqueFilename);
 					map.put("passageScope", q.getCommonPassage().getRangeText());
-					
+
 					// 파일 저장
 	                String fileKey = q.getCommonPassage().getFileKey();
 	                MultipartFile file = request.getFileMap().get(fileKey);
 					ensureImageFolderExists(folderPath, uniqueFilename, file);
 				} else if(q.getCommonPassage().getType().equals("text")) {
 					map.put("commonPassage", q.getCommonPassage().getContent());
-					map.put("passageScope", q.getCommonPassage().getRangeText());	
+					map.put("passageScope", q.getCommonPassage().getRangeText());
 				}
 			}
-			
+
 			// 선택지
 			List<QuestionChoice> choices = q.getQuestionChoices();
 			List<ExamChoiceDto> newChoiceList = new ArrayList<>();
@@ -320,11 +331,11 @@ public class ExamSelectionService implements IExamSelectionService {
 			}
 			map.put("options", newChoiceList);
 			newList.add(map);
-			
+
 			// 정답지
 			map.put("answer", q.getAnswerText());
 		}
-		
+
 		return new ParsedExamData(examInfo, newList);
 	}
 
@@ -333,20 +344,20 @@ public class ExamSelectionService implements IExamSelectionService {
 		String storageType = config.getImageStorageType();
 		if("local".equals(storageType) || "prod".equals(storageType)) {
 			Path fullPath = Paths.get(config.getImageUploadPath(), folderPath);
-			
+
 			// 폴더 생성
 			try {
 				if(Files.notExists(fullPath)) {
 					Files.createDirectories(fullPath);
 				}
-				
+
 				// 파일 저장
 				Path filePath = fullPath.resolve(filename);
-				
+
 				try(InputStream is = file.getInputStream()){
 					Files.copy(is, filePath, StandardCopyOption.REPLACE_EXISTING);
 				}
-				
+
 				return "/exam/getExamImagePath?filename=" + filename;
 			} catch (Exception e) {
 				e.printStackTrace();
@@ -366,15 +377,15 @@ public class ExamSelectionService implements IExamSelectionService {
 	public List<Map<String, Object>> parsePdfToQuestions(MultipartFile file) throws Exception {
 		// 1. PDF 텍스트 추출
 		String text = extractor.extract(file);
-		
+
 		// 2. 한글 spacing 정리 및 좌/우 단 섞임 복구
 		text = normalizer.normalize(text);
 //		text = PdfTextNormalizer.normalize(text);
-		
+
 		if(text == null || text.trim().isEmpty()) {
 			throw new Exception("PDF에서 텍스트를 읽을 수 없습니다. PDF 파일인지 확인해주세요.");
 		}
-		
+
 		// 3. 파서를 이용하여 텍스트를 List<Map> 구조로 변환
 		return gedExamParser.parse(text);
 	}
@@ -426,7 +437,7 @@ public class ExamSelectionService implements IExamSelectionService {
 		if(content == null || !content.contains("<img")) {
 			return content; // 이미지가 없으면 바로 반환
 		}
-		
+
 		// <img 태그의 src 속성 내 filename 파라미터 값을 추출하는 정규표현식
 		Pattern pattern = Pattern.compile("(filename=|/temp/)([^&\"'\\s>]+)");
 	    Matcher matcher = pattern.matcher(content);
@@ -489,19 +500,19 @@ public class ExamSelectionService implements IExamSelectionService {
 				request.getQuestion().getQuestionAnswer(),
 				request.getExamInfo().getExamId());
 	}
-	
+
 	private void updateQuestion(CreateExamInfo i, Question q, Map<String, MultipartFile> fileMap) {
 		// 시험지 정보
 		String examType = i.getTypeKor();
 		String examRound = i.getRound();
 		String examSubject = i.getSubject();
-		
+
 		// 시험지
 		Integer questionid = q.getQuestionId();
 		String questionText = q.getQuestionText();
 		char useCommonPassage = q.getUseCommonPassage();
 		char useIndividualPassage = q.getUseIndividualPassage();
-		
+
 		// 시험지 객체에 데이터 파싱
 		ExamQuestionDto dto = new ExamQuestionDto();
 		dto.setQuestionId(questionid);
@@ -511,11 +522,11 @@ public class ExamSelectionService implements IExamSelectionService {
 			String type = commonPassage.getType();
 			String content = commonPassage.getContent();
 			String rangeText = commonPassage.getRangeText();
-			
+
 			String newContent = content;
 			if(type.equals("image")) {
 				String fileKey = commonPassage.getFileKey();
-				
+
 				if(fileKey != null && !fileKey.isEmpty()) {
 					// 폴더이름 생성
 					String folderPath = String.join("/", examType, examRound, examSubject);
@@ -523,34 +534,34 @@ public class ExamSelectionService implements IExamSelectionService {
 					// 파일이름 생성
 					String filename = content.trim().replace(" ", "");
 					String uniqueFilename = UUID.randomUUID().toString() + "_" + filename;
-					
+
 					// 파일 저장
 					MultipartFile file = fileMap.get(fileKey);
-					
+
 					ensureImageFolderExists(folderPath, uniqueFilename, file);
 					newContent = uniqueFilename;
 				}
 			} else if(type.equals("text")) {
 				newContent = processHtmlEmbeddedImages(
-						content, 
-						examType, 
-						examRound, 
+						content,
+						examType,
+						examRound,
 						examSubject
 				);
 			}
 			dto.setCommonPassage(newContent);
 			dto.setPassageScope(rangeText);
 		}
-		
+
 		if(useIndividualPassage == 'Y') {
 			IndividualPassage individualPassage = q.getIndividualPassage();
 			String type = individualPassage.getType();
 			String content = individualPassage.getContent();
-			
+
 			String newContent = content;
 			if(type.equals("image")) {
 				String individualFileKey = individualPassage.getFileKey();
-				
+
 				if(individualFileKey != null && !individualFileKey.isEmpty()) {
 					// 폴더이름 생성
 					String folderPath = String.join("/", examType, examRound, examSubject);
@@ -558,27 +569,27 @@ public class ExamSelectionService implements IExamSelectionService {
 					// 파일이름 생성
 					String filename = content.trim().replace(" ", "_");
 					String uniqueFilename = UUID.randomUUID().toString() + "_" + filename;
-					
+
 					// 파일 저장
 					MultipartFile file = fileMap.get(individualFileKey);
-					
+
 					ensureImageFolderExists(folderPath, uniqueFilename, file);
 					newContent = uniqueFilename; // 새로운 파일 이름을 content로 재생성
-				} 
+				}
 			} else if(type.equals("text")) {
 				newContent = processHtmlEmbeddedImages(
-						content, 
-						examType, 
-						examRound, 
+						content,
+						examType,
+						examRound,
 						examSubject
 				); // <img>태그의 src경로를 파일이름만 남긴채로 content를 재생성
 			}
 			dto.setIndividualPassage(newContent);
 		}
-		
+
 		dao.updateQuestion(dto);
 	}
-	
+
 	private void updateQuestionChoices(Integer examId, List<QuestionChoice> choice, Integer questionId) {
 		for(QuestionChoice c : choice) {
 			String tempId = c.getTempId();
@@ -604,14 +615,14 @@ public class ExamSelectionService implements IExamSelectionService {
 			}
 		}
 	}
-	
+
 	@Override
 	public int getExamIdByExamTypeId(String examTypeCode, String examRound, String examSubject) {
 		Map<String, Object> map = new HashMap<>();
 		map.put("examTypeEng", examTypeCode);
 		map.put("examRound", examRound);
 		map.put("examSubject", examSubject);
-		
+
 		return dao.getExamIdByExamTypeId(map);
 	}
 
@@ -628,7 +639,7 @@ public class ExamSelectionService implements IExamSelectionService {
 	@Override
 	public ChartStatisticsDto getChartStatistics() {
 		return new ChartStatisticsDto(
-				dao.getTotalExamCount(), 
+				dao.getTotalExamCount(),
 				dao.getMissingAnswerExams()
 		);
 	}

--- a/src/main/java/com/my/ex/service/IExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/IExamSelectionService.java
@@ -1,12 +1,5 @@
 package com.my.ex.service;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.springframework.web.multipart.MultipartFile;
-
 import com.my.ex.dto.ExamChoiceDto;
 import com.my.ex.dto.ExamInfoDto;
 import com.my.ex.dto.ExamQuestionDto;
@@ -17,6 +10,12 @@ import com.my.ex.dto.response.ChartStatisticsDto;
 import com.my.ex.dto.response.ExamPageDto;
 import com.my.ex.dto.response.ExamTitleDto;
 import com.my.ex.dto.service.ParsedExamData;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public interface IExamSelectionService {
 	List<ExamTypeDto> getExamTypes();
@@ -24,7 +23,7 @@ public interface IExamSelectionService {
 	List<ExamTypeDto> getExamPaperTypes();
 	List<String> getExamRounds(String examTypeCode);
 	List<String> getSubjectsByExamRound(String examTypeCode, String examRound);
-	List<ExamTitleDto> getAllExamTitlesByFolderId(int folderId);
+	List<ExamTitleDto> getAllExamTitlesByFolderId(int folderId, int page);
 	boolean saveParsedExamData(ExamInfoDto examInfo, List<Map<String, Object>> questions);
 	String getExamtypename(String examType);
 	List<ExamQuestionDto> getExamQuestions(String examType, String examRound, String examSubject);

--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -123,42 +123,48 @@
 	</select>
 	
 	<!-- 특정 폴더에 있는 모든 시험지/정답지 정보 가져옴 -->
-	<select id="getAllExamTitlesByFolderId" resultType="ExamTitleDto">
-		SELECT
-			 i.exam_type_id AS examTypeId,
-			 t.exam_type_code AS examTypeCode,
-			 t.exam_type_name AS examTypeName, 
-		     
-		     i.exam_id AS examId,
-		     i.exam_round AS examRound,
-		     i.exam_subject AS examSubject,
-		     
-		     CASE
-		     	WHEN t.exam_type_code LIKE '%Answer' THEN
-		     	    (SELECT COUNT(*) 
-		               FROM exam_answer a 
-		              WHERE a.exam_id = i.exam_id)
-		        ELSE
-				    (SELECT COUNT(*) 
-		               FROM exam_question q 
-		              WHERE q.exam_id = i.exam_id)
-			END AS totalCount,
+	<select id="getAllExamTitlesByFolderId" parameterType="java.util.HashMap" resultType="ExamTitleDto">
+		SELECT * FROM (
+			SELECT a.*, ROWNUM AS rnum FROM (
+				(SELECT
+					 i.exam_type_id AS examTypeId,
+					 t.exam_type_code AS examTypeCode,
+					 t.exam_type_name AS examTypeName,
 
-			CASE
-				WHEN t.exam_type_code LIKE '%Answer' THEN
-					CONCAT(i.exam_subject, ' - 정답지')
-				ELSE
-					i.exam_subject
-			END AS displaySubject,
-			
-             i.created_date,
-             f.folder_id
-		  FROM exam_info i
-		  JOIN exam_type t ON i.exam_type_id = t.exam_type_id
-		  JOIN exam_folder f ON i.folder_id = f.folder_id
-		  WHERE f.folder_id = #{folderId}
-		    AND i.isdeleted = 'N'
-		  ORDER BY i.created_date DESC
+					 i.exam_id AS examId,
+					 i.exam_round AS examRound,
+					 i.exam_subject AS examSubject,
+
+					 CASE
+						WHEN t.exam_type_code LIKE '%Answer' THEN
+							(SELECT COUNT(*)
+							   FROM exam_answer a
+							  WHERE a.exam_id = i.exam_id)
+						ELSE
+							(SELECT COUNT(*)
+							   FROM exam_question q
+							  WHERE q.exam_id = i.exam_id)
+					END AS totalCount,
+
+					CASE
+						WHEN t.exam_type_code LIKE '%Answer' THEN
+							CONCAT(i.exam_subject, ' - 정답지')
+						ELSE
+							i.exam_subject
+					END AS displaySubject,
+
+					 i.created_date,
+					 f.folder_id
+				  FROM exam_info i
+				  JOIN exam_type t ON i.exam_type_id = t.exam_type_id
+				  JOIN exam_folder f ON i.folder_id = f.folder_id
+				  WHERE f.folder_id = #{folderId}
+					AND i.isdeleted = 'N'
+				  ORDER BY i.created_date DESC)
+			) a
+			WHERE ROWNUM &lt;= #{endRow}
+		)
+		WHERE rnum &gt;= #{startRow}
 	</select>
 		
 	<!-- 중복 시험 여부 확인 -->

--- a/src/main/webapp/WEB-INF/views/admin/main.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/main.jsp
@@ -151,6 +151,12 @@
 			
 			<!-- 시험지 목록 섹션 -->
 			<div class="exam-card-grid"><!-- 폴더 클릭 시 동적으로 생성 --></div>
+
+			<!-- 무한 스크롤 감지 지점 -->
+			<div id="scroll-sentinel" style="height: 20px;"></div>
+			<div id="list-loader" style="display: none; text-align: center; padding: 20px;">
+				<i class="fas fa-spinner fa-spin"></i> 데이터를 불러오는 중입니다...
+			</div>
 			
 			<!-- 페이징 -->
 			<!-- <div class="pagination-area">

--- a/src/main/webapp/resources/js/admin_main.js
+++ b/src/main/webapp/resources/js/admin_main.js
@@ -3,6 +3,11 @@ let activeFolderId = null
 let activeFolderName = null
 let defaultFolderId = 1
 
+// 무한 스크롤
+let currentPage = 1 // 현재 페이지
+let isLoading = false // 중복 요청 방지
+let hasMore = true // 더 가져올 데이터가 있는지
+
 // PDF 분석 완료 여부
 let isAnalyzed = false
 
@@ -237,6 +242,7 @@ document.addEventListener('DOMContentLoaded', () => {
         location.href = `/admin/createExamPage?folderId=${activeFolderId}`
     })
 
+    initScroll()
     ChartHandler.init()
 })
 
@@ -540,10 +546,10 @@ const loadBulkActionBtn = () => {
 }
 
 // 폴더 내 시험지 목록 UI
-const renderExamList = (exaxmList, noDataMessage) => {
+const renderExamList = (examList, noDataMessage) => {
     let output = ''
 
-    if(exaxmList.length == 0){
+    if(examList.length == 0 && noDataMessage != null){
         output += 
         `
             <div class="no-exams-message">
@@ -552,7 +558,7 @@ const renderExamList = (exaxmList, noDataMessage) => {
             </div>
         `
     } else {
-        exaxmList.forEach((examTitleDto) => {
+        examList.forEach((examTitleDto) => {
 
             output += 
             `
@@ -594,6 +600,8 @@ const renderExamList = (exaxmList, noDataMessage) => {
 
 // 폴더 내 시험지 목록 UI 로드 함수
 const loadExamListData = (folderId) => {
+    currentPage = 1
+    isLoading = true
 
     // 시험지 이동 버튼 컨테이너
     const listAction = document.querySelector(".exam-list-actions")
@@ -612,11 +620,67 @@ const loadExamListData = (folderId) => {
     axios.get('/admin/examList', { params })
         .then(response => {
             examCard.innerHTML = renderExamList(response.data, '등록된 시험지 목록이 없습니다. 새로운 시험지를 등록해주세요.')
+            if(response.data.length < 9){
+                hasMore = false
+            } 
         })
         .catch(error => {
             console.error('error: ', error)
         })
+        .finally(() => {
+            isLoading = false
+        })
 }
+
+const initScroll = () => {
+    const sentinel = document.querySelector("#scroll-sentinel")
+    if(!sentinel) return
+
+    const observer = new IntersectionObserver((entries) => {
+        if(entries[0].isIntersecting && hasMore && activeFolderId){
+            loadMoreExams(activeFolderId)
+        }
+    })
+
+    observer.observe(sentinel)
+}
+
+const loadMoreExams = (folderId) => {
+    if(isLoading || !hasMore) return
+
+    isLoading = true // 중복 요청 방지를 위한 로딩 잠금
+
+    const loadMessage = document.querySelector("#list-loader")
+    loadMessage.style.display = 'block'
+
+    const params = {
+        folderId: folderId,
+        page: currentPage
+    }
+    
+    setTimeout(() => {
+        axios.get('/admin/examList', { params })
+        .then(response => {
+                const newExamList = response.data
+                const examCard = document.querySelector(".exam-card-grid")
+                examCard.insertAdjacentHTML("beforeend", renderExamList(newExamList, null))
+
+                if(newExamList.length < 9){
+                    hasMore = false
+                } else {
+                    currentPage++
+                }
+            })
+            .catch(error => {
+                console.error('error: ', error)
+            })
+            .finally(() => {
+                loadMessage.style.display = 'none'
+                isLoading = false // 데이터 로딩 완료 후 잠금 해제
+            })
+    }, 800);
+}
+
 
 // 시험지 상세보기 페이지로 이동하는 함수
 const viewExam = (examId, examTypeCode, examTypeName, examRound, examSubject) => {
@@ -1169,6 +1233,11 @@ const clearSelections = () => {
 
     // 폴더 id 초기화
     activeFolderId = null
+
+    // 무한 스크롤 관련 변수 초기화
+    currentPage = 1
+    isLoading = false
+    hasMore = true
 
     ChartHandler.init()
 }


### PR DESCRIPTION
## 📌 변경 사항
- **Intersection Observer API 기반 무한 스크롤 도입**: 리스트 하단 `Sentinel` 감지 시 다음 페이지 데이터를 비동기(`Axios`)로 호출하는 로직을 추가
- **데이터 로딩 잠금(Locking) 시스템 적용**: `isLoading` 플래그를 사용하여 데이터 요청 중 발생하는 중복 스크롤 감지 및 중복 API 호출을 원천 차단
- **페이징 상태 관리**: `currentPage`를 통한 페이지 트래킹과 `hasMore` 플래그를 이용한 마지막 데이터 판별 로직을 구현
- **UI/UX 개선**: 데이터 로드 시 하단 스피너(`#list-loader`) 노출 및 `setTimeout`을 활용한 자연스러운 로딩 연출을 적용

## 🛠️ 수정한 이유
- **사용자 경험 개선**: 기존의 정적 목록 방식에서 벗어나 사용자가 스크롤만으로 많은 양의 시험지를 끊김 없이 탐색할 수 있도록 개선
- **서버 부하 분산**: 모든 데이터를 한 번에 가져오지 않고 9개 단위로 페이징 처리하여 초기 로딩 속도를 높이고 서버 자원을 효율적으로 사용하기 위함
- **데이터 정합성 보장**: 비동기 통신 시 발생할 수 있는 데이터 중복 렌더링 문제를 `isLoading` 로직으로 해결하여 안정성을 높임

## 🔍 주요 변경 파일
- AdminController.java
- ExamSelectionService.java
- ExamSelectionDao.java
- ExamSelectionmapper.xml
- /admin/main.jsp
- admin_main.js

## ✅ 테스트 내용
- [x] 페이지 하단 도달 시 다음 페이지(9개) 데이터가 정상적으로 추가되는지 확인
- [x] 데이터 로딩 중 추가 스크롤 발생 시 API 중복 호출이 차단되는지 확인
- [x] 마지막 페이지 로드 후 더 이상 요청이 가지 않는지 확인
- [x] 데이터가 없는 폴더 진입 시 "등록된 시험지가 없습니다" 메시지 정상 표시 확인

## 🔗 관련 이슈 
closes #55 