### PR TITLE
[FEAT] 시험지 검색 결과 무한 스크롤

### DIFF
--- a/src/main/java/com/my/ex/dto/request/ExamSearchDto.java
+++ b/src/main/java/com/my/ex/dto/request/ExamSearchDto.java
@@ -10,4 +10,13 @@ public class ExamSearchDto {
 	private String year;
 	private String round;
 	private int activeFolderId;
+	private int page;
+
+	// DB 조회용
+	private int startRow;
+	private int endRow;
+
+	public void setPage(int page) {
+		this.page = page == 0 ? 1 : page;
+	}
 }

--- a/src/main/java/com/my/ex/service/ExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/ExamSelectionService.java
@@ -35,6 +35,8 @@ import java.util.regex.Pattern;
 
 @Service
 public class ExamSelectionService implements IExamSelectionService {
+	// 한 페이지당 보여줄 게시글 수
+	private final int COUNT = 9;
 
 	@Autowired
 	private ExamSelectionDao dao;
@@ -85,22 +87,16 @@ public class ExamSelectionService implements IExamSelectionService {
 
 	@Override
 	public List<ExamTitleDto> getAllExamTitlesByFolderId(int folderId, int page) {
-		// 한 페이지당 보여줄 게시글 수
-		final int COUNT = 9;
-
-		int endRow = page * COUNT;
-		int startRow = endRow - (COUNT - 1);
-
-		Map<String, Object> map = new HashMap<>();
+		Map<String, Object> map = calculateOffset(page);
 		map.put("folderId", folderId);
-		map.put("startRow", startRow);
-		map.put("endRow", endRow);
 
 		return dao.getAllExamTitlesByFolderId(map);
 	}
 
 	@Override
-	public boolean saveParsedExamData(ExamInfoDto examInfo, List<Map<String, Object>> questions) {
+	@Transactional
+	public boolean
+	saveParsedExamData(ExamInfoDto examInfo, List<Map<String, Object>> questions) {
 		// 과목명으로 subject_id 조회 및 set
 		Map<String, Object> map = new HashMap<>();
 		map.put("examSubject", examInfo.getExamSubject());
@@ -633,6 +629,10 @@ public class ExamSelectionService implements IExamSelectionService {
 
 	@Override
 	public List<ExamTitleDto> searchExams(ExamSearchDto dto) {
+		Map<String, Object> map = calculateOffset(dto.getPage());
+		dto.setStartRow((Integer) map.get("startRow"));
+		dto.setEndRow((Integer) map.get("endRow"));
+
 		return dao.searchExams(dto);
 	}
 
@@ -642,6 +642,17 @@ public class ExamSelectionService implements IExamSelectionService {
 				dao.getTotalExamCount(),
 				dao.getMissingAnswerExams()
 		);
+	}
+
+	private Map<String, Object> calculateOffset(int page){
+		int endRow = page * COUNT;
+		int startRow = endRow - (COUNT - 1);
+
+		Map<String, Object> map = new HashMap<>();
+		map.put("startRow", startRow);
+		map.put("endRow", endRow);
+
+		return map;
 	}
 
 }

--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -126,7 +126,7 @@
 	<select id="getAllExamTitlesByFolderId" parameterType="java.util.HashMap" resultType="ExamTitleDto">
 		SELECT * FROM (
 			SELECT a.*, ROWNUM AS rnum FROM (
-				(SELECT
+				 SELECT
 					 i.exam_type_id AS examTypeId,
 					 t.exam_type_code AS examTypeCode,
 					 t.exam_type_name AS examTypeName,
@@ -160,7 +160,7 @@
 				  JOIN exam_folder f ON i.folder_id = f.folder_id
 				  WHERE f.folder_id = #{folderId}
 					AND i.isdeleted = 'N'
-				  ORDER BY i.created_date DESC)
+				  ORDER BY i.created_date DESC
 			) a
 			WHERE ROWNUM &lt;= #{endRow}
 		)
@@ -431,65 +431,71 @@
 	
 	<!-- 시험지 검색 -->
 	<select id="searchExams" parameterType="ExamSearchDto" resultType="ExamTitleDto">
-		SELECT
-			 i.exam_type_id AS examTypeId,
-			 t.exam_type_code AS examTypeCode,
-			 t.exam_type_name AS examTypeName, 
-		     
-		     i.exam_id AS examId,
-		     i.exam_round AS examRound,
-		     i.exam_subject AS examSubject,
-		     
-		     CASE
-		     	WHEN t.exam_type_code LIKE '%Answer' THEN
-		     	    (SELECT COUNT(*) 
-		               FROM exam_answer a 
-		              WHERE a.exam_id = i.exam_id)
-		        ELSE
-				    (SELECT COUNT(*) 
-		               FROM exam_question q 
-		              WHERE q.exam_id = i.exam_id)
-			END AS totalCount,
+		SELECT * FROM (
+			SELECT a.*, ROWNUM AS rnum FROM (
+				SELECT
+					 i.exam_type_id AS examTypeId,
+					 t.exam_type_code AS examTypeCode,
+					 t.exam_type_name AS examTypeName,
 
-			CASE
-				WHEN t.exam_type_code LIKE '%Answer' THEN
-					CONCAT(i.exam_subject, ' - 정답지')
-				ELSE
-					i.exam_subject
-			END AS displaySubject,
-			
-             i.created_date,
-             f.folder_id
-		  FROM exam_info i
-		  JOIN exam_type t ON i.exam_type_id = t.exam_type_id
-		  JOIN exam_folder f ON i.folder_id = f.folder_id
-		  <where>
-			  	AND f.folder_id = #{activeFolderId}
-			    AND i.isdeleted = 'N'
-			    
-			    <if test="keyword != null and keyword != ''">
-		            AND (t.exam_type_name LIKE '%' || #{keyword} || '%' 
-		            	OR i.exam_subject LIKE '%' || #{keyword} ||'%'
-		            	OR i.exam_round LIKE '%' || #{keyword} ||'%')
-		        </if>
-		        
-		        <if test="type != null and type != ''">
-		            AND t.exam_type_code = #{type}
-		        </if>
-		        
-		        <if test="subject != null and subject != ''">
-		            AND i.exam_subject = #{subject}
-		        </if>
-		        
-		        <if test="year != null and year != ''">
-		            AND i.exam_round LIKE '%' || #{year} || '%'
-		        </if>
-		        
-		        <if test="round != null and round != ''">
-		            AND i.exam_round LIKE '%' || #{round} || '%'
-		        </if>
-		  </where>
-		  ORDER BY i.created_date DESC	
+					 i.exam_id AS examId,
+					 i.exam_round AS examRound,
+					 i.exam_subject AS examSubject,
+
+					 CASE
+						WHEN t.exam_type_code LIKE '%Answer' THEN
+							(SELECT COUNT(*)
+							   FROM exam_answer a
+							  WHERE a.exam_id = i.exam_id)
+						ELSE
+							(SELECT COUNT(*)
+							   FROM exam_question q
+							  WHERE q.exam_id = i.exam_id)
+					END AS totalCount,
+
+					CASE
+						WHEN t.exam_type_code LIKE '%Answer' THEN
+							CONCAT(i.exam_subject, ' - 정답지')
+						ELSE
+							i.exam_subject
+					END AS displaySubject,
+
+					 i.created_date,
+					 f.folder_id
+				  FROM exam_info i
+				  JOIN exam_type t ON i.exam_type_id = t.exam_type_id
+				  JOIN exam_folder f ON i.folder_id = f.folder_id
+				  <where>
+						AND f.folder_id = #{activeFolderId}
+						AND i.isdeleted = 'N'
+
+						<if test="keyword != null and keyword != ''">
+							AND (t.exam_type_name LIKE '%' || #{keyword} || '%'
+								OR i.exam_subject LIKE '%' || #{keyword} ||'%'
+								OR i.exam_round LIKE '%' || #{keyword} ||'%')
+						</if>
+
+						<if test="type != null and type != ''">
+							AND t.exam_type_code = #{type}
+						</if>
+
+						<if test="subject != null and subject != ''">
+							AND i.exam_subject = #{subject}
+						</if>
+
+						<if test="year != null and year != ''">
+							AND i.exam_round LIKE '%' || #{year} || '%'
+						</if>
+
+						<if test="round != null and round != ''">
+							AND i.exam_round LIKE '%' || #{round} || '%'
+						</if>
+				  </where>
+				  ORDER BY i.created_date DESC
+			) a
+			WHERE ROWNUM &lt;= #{endRow}
+		)
+		WHERE rnum &gt;= #{startRow}
 	</select>
 	
 	<!-- 전체 시험지 개수 조회 -->

--- a/src/main/webapp/resources/js/admin_main.js
+++ b/src/main/webapp/resources/js/admin_main.js
@@ -8,6 +8,9 @@ let currentPage = 1 // 현재 페이지
 let isLoading = false // 중복 요청 방지
 let hasMore = true // 더 가져올 데이터가 있는지
 
+let currentSearchPage = 1
+let isSearching = false
+
 // PDF 분석 완료 여부
 let isAnalyzed = false
 
@@ -96,7 +99,9 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelector("#searchForm").addEventListener('submit', (e) => {
         // 엔터키와 검색 버튼 클릭 모두 감지
         e.preventDefault()
-        handleSearch()
+        currentSearchPage = 1
+        const searchParams = handleSearch()
+        fetchSearchExams(searchParams)
     })
 
     // 새 폴더 모달 닫기 버튼 리스너
@@ -638,11 +643,48 @@ const initScroll = () => {
 
     const observer = new IntersectionObserver((entries) => {
         if(entries[0].isIntersecting && hasMore && activeFolderId){
-            loadMoreExams(activeFolderId)
+            if(isSearching){
+                const searchParams = handleSearch()
+                loadMoreSearchExams(searchParams)
+            } else {
+                loadMoreExams(activeFolderId)
+            }
         }
     })
 
     observer.observe(sentinel)
+}
+
+const loadMoreSearchExams = (params) => {
+    if(isLoading || !hasMore) return
+
+    isLoading = true // 중복 요청 방지를 위한 로딩 잠금
+
+    const loadMessage = document.querySelector("#list-loader")
+    loadMessage.style.display = 'block'
+
+    setTimeout(() => {
+        axios.get('/exam/searchExams', { params })
+        .then(response => {
+                const newExamSearchList = response.data
+                const examCard = document.querySelector(".exam-card-grid")
+                examCard.insertAdjacentHTML("beforeend", renderExamList(newExamSearchList, null))
+
+                if(newExamSearchList.length < 9){
+                    hasMore = false
+                    isSearching = false
+                } else {
+                    currentSearchPage++
+                }
+            })
+            .catch(error => {
+                console.error('error: ', error)
+            })
+            .finally(() => {
+                loadMessage.style.display = 'none'
+                isLoading = false // 데이터 로딩 완료 후 잠금 해제
+            })
+    }, 800);
 }
 
 const loadMoreExams = (folderId) => {
@@ -723,6 +765,7 @@ const handleSearch = () => {
     const subject = form.querySelector("#searchSubject").value
     const year = form.querySelector("#searchYear").value
     const round = form.querySelector("#searchRound").value
+    const page = currentSearchPage
     
     if(!keyword && !type && !subject && !year && !round){
         alert("최소 하나 이상의 검색 조건을 선택하거나 키워드를 입력해주세요.")
@@ -735,25 +778,39 @@ const handleSearch = () => {
         subject,
         year,
         round,
-        activeFolderId
+        activeFolderId,
+        page
     }
 
-    fetchSearchExams(params)
+    return params
+    // fetchSearchExams(params)
 }
 
 // 검색 조건에 맞는 시험지 목록 요청 함수
 const fetchSearchExams = (params) => {
+    isSearching = true
+    isLoading = true
+    
     const examCard = document.querySelector(".exam-card-grid")
     axios.get('/exam/searchExams', { params })
         .then(response => {
             examCard.innerHTML = renderExamList(response.data, "검색 결과가 없습니다.")
-
+            
+            if(response.data.length < 9){
+                hasMore = false
+                isSearching = false
+            } else {
+                currentSearchPage++
+            }
             folderView.style.display = 'none'               // 폴더 뷰 숨김
             examListView.style.display = 'block'            // 시험지 뷰 표시
             btnCreateExam.style.display = 'inline-flex'     // 새 시험지 등록 버튼 표시
         })
         .catch(error => {
             console.error('error: ', error)
+        })
+        .finally(() => {
+            isLoading = false
         })
 }
 
@@ -1235,9 +1292,14 @@ const clearSelections = () => {
     activeFolderId = null
 
     // 무한 스크롤 관련 변수 초기화
+    // 메인 페이지 리스트
     currentPage = 1
     isLoading = false
     hasMore = true
+
+    // 검색 페이지 리스트
+    currentSearchPage = 1
+    isSearching = false
 
     ChartHandler.init()
 }


### PR DESCRIPTION
## 📌 변경 사항
- **검색 전용 상태 플래그(`isSearching`) 도입**: 메인 페이지의 일반 리스트 호출과 검색 결과 리스트 호출을 명확히 구분하여, 현재 상태에 맞는 무한 스크롤 데이터가 로드되도록 제어 로직을 추가
- **기존 상태 변수 재사용**: 기존 무한 스크롤에서 사용하던 `isLoading`, `hasMore` 변수 재사용
- **Oracle 3중 서브쿼리 페이징 적용**: 검색 필터가 포함된 복잡한 쿼리에서도 `ROWNUM`에 의한 데이터 누락이 없도록 안정적인 페이징 구조를 확보
- **검색 상태 동기화**: '검색' 버튼 클릭 시 페이지 번호를 초기화하고 검색 모드로 전환하는 로직을 통해 데이터 정합성을 확보

## 🛠️ 수정한 이유
- 사용자 편의성을 위해 버튼 클릭 대신 스크롤만으로 많은 양의 검색 결과를 확인할 수 있도록 무한 스크롤 방식을 도입하여 탐색 경험을 향상

## 🔍 주요 변경 파일
- ExamSearchDto.java
- ExamSelectionService.java
- ExamSelectionmapper.xml
- admin_main.js

## ✅ 테스트 내용
- [x] 다양한 검색 조건(과목, 타입 등) 조합 시 데이터 정상 로드 확인
- [x] 스크롤 하단 도달 시 다음 페이지 데이터(10번 행 이후) 누락 없이 표시 확인
- [x] 검색 결과가 9개 미만인 경우 더 이상 불필요한 요청을 하지 않는지 확인
- [x] 기존 폴더 뷰 및 일반 시험지 목록 조회 기능에 영향 없는지 확인

## 🔗 관련 이슈
closes #57 