### PR TITLE
[BUG] URL 파라미터 RFC 3986 표준 미준수 및 인코딩 누락 수정

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/exam_page.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/exam_page.jsp
@@ -22,8 +22,9 @@
                 <span><i class="fas fa-book"></i> 과목: ${examPageDto.examSubject}</span>
                 <span><i class="fas fa-tag"></i> 유형/회차: ${examPageDto.examRound}</span>
                 <button class="btn btn-back" 
-                	onclick="location.href='/admin/main?folderId=${folderDto.folderId}&folderName=${folderDto.folderName}'"
-               	>
+                    onclick="location.href='/admin/main?folderId=${folderDto.folderId}&folderName=' + encodeURIComponent('${folderDto.folderName}'.trim())"
+                >
+                <!-- onclick="location.href='/admin/main?folderId=${folderDto.folderId}&folderName=${folderDto.folderName}'" -->
                 	<i class="fas fa-list-ul"></i> 목록으로
                	</button>
             </div>


### PR DESCRIPTION
## 📌 변경 사항
- `exam_page.jsp` 내 '목록으로' 버튼의 이동 경로 생성 로직에 `encodeURIComponent()` 적용
- 파라미터로 전달되는 폴더명 문자열에 `.trim()`을 추가하여 불필요한 공백 제거

## 🛠️ 수정한 이유
- 보안으로 인해 URL에 포함된 특수문자([, ])와 공백이 RFC 3986 규격 위반으로 인식되어 페이지 접근이 차단되는 현상을 해결하기 위함

## 🔍 주요 변경 파일
- /admin/exam_page.jsp

## ✅ 테스트 내용
- [x] 특수문자([])가 포함된 폴더에서 목록으로 돌아가기 기능 동작 확인
- [x] 폴더명 양 끝에 공백이 있을 경우 정상적으로 제거되어 이동하는지 확인
- [x] 400/500 에러 없이 페이지 렌더링 확인
 
## 🔗 관련 이슈
closes #59 
