### PR TITLE
[ENH] 과목별 예상 문항 수 필터링 및 관리자 안내 메시지 개선

### DIFF
--- a/src/main/java/com/my/ex/controller/ExamSelectionController.java
+++ b/src/main/java/com/my/ex/controller/ExamSelectionController.java
@@ -309,7 +309,8 @@ public class ExamSelectionController {
 			
 			boolean result = false;
 			List<Map<String, Object>> questions = null;
-			
+			int expectedSize = "수학".equals(examSubject) ? 20 : 25;
+
 			// 검정고시 시험지인 경우
 			if(examTypeCode.endsWith("geomjeong")) {
 				// 1. 시험지 PDF 텍스트 추출 후 파싱된 전체 문제 리스트를 반환
@@ -318,6 +319,12 @@ public class ExamSelectionController {
 					String message = 
 							"PDF에서 시험지를 추출할 수 없습니다. \n" +
 							"정답지 PDF를 업로드하려면 시험 유형을 '정답지'로 선택해주세요.";
+					return new ExamPdfPreview(false, message, null);
+				} else if(questions.size() != expectedSize){
+					String message =
+							"현재 PDF에서 문항을 정확히 읽어오지 못했습니다. \n" +
+							"❌ 추출된 문항: " + questions.size() + "개 / 예상: " + expectedSize +"개 \n\n" +
+							"텍스트 선택이 가능한 PDF인지 확인해 주시고, 지속적으로 실패할 경우 [시험지 직접 등록] 메뉴를 통해 진행해 주시기 바랍니다.";
 					return new ExamPdfPreview(false, message, null);
 				}
 				


### PR DESCRIPTION
## 📌 변경 사항
- 서버 측 `loadPdfFile` 컨트롤러에 파싱된 문항 수와 과목별 예상 문항 수 비교 로직 추가
- 수학(20문항)과 그 외 과목(25문항)에 대한 `expectedSize` 분기 처리
- 파싱 실패 시 사용자에게 노출되는 `alert` 메시지에 이모지와 상세 수치를 추가하여 가독성 개선

## 🛠️ 수정한 이유
- PDF 텍스트 추출이 불완전할 경우(일부 문항 누락 등) 잘못된 데이터가 DB에 등록되는 것을 방지하여 데이터 무결성을 확보하기 위함
- 자동 등록 실패 시 관리자에게 명확한 이유를 알리고 '수동 등록'이라는 대안을 제시하여 사용자 경험(UX)을 향상시키기 위함

## 🔍 주요 변경 파일
- ExamSelectionController.java

## ✅ 테스트 내용
- [x] 문항 수가 일치하지 않는 PDF 업로드 시 등록 차단 및 경고창 표시 확인
- [x] 수학 과목(20문항) 업로드 시 정상 등록 여부 확인
- [x] 경고창 내 이모지 및 줄바꿈 등 UI 가독성 확인
## 🔗 관련 이슈
closes #60 
