### PR TITLE
[BUG] 시험 유형별 정답지 매칭 로직 오류 수정 (중졸/고졸 데이터 간섭 해결)

### DIFF
--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -529,6 +529,7 @@
 		    JOIN exam_type t2 ON t2.exam_type_id = i2.exam_type_id
 		    WHERE t2.exam_type_code LIKE '%Answer'
 		    AND i2.isdeleted = 'N'
+			AND t2.exam_type_code = CONCAT(t.exam_type_code, 'Answer')
 		    AND i.exam_round = i2.exam_round
 		    AND i.exam_subject = i2.exam_subject
 		)


### PR DESCRIPTION
## 📌 변경 사항
- `exam_info` 테이블에서 미등록 정답지를 조회하는 쿼리 로직 수정
- `NOT EXISTS` 절 내부에 `t2.exam_type_code = CONCAT(t.exam_type_code, 'Answer')` 조건 추가

## 🛠️ 수정한 이유
- 기존 쿼리는 시험 유형(중졸/고졸)을 구분하지 않고 회차와 과목명만 비교함
- 이로 인해 '중졸 사회 정답지'가 존재할 경우, '고졸 사회 시험지'의 정답지가 없음에도 불구하고 목록에서 누락되는 데이터 정합성 오류 발생

## 🔍 주요 변경 파일
- ExamSelectionmapper.xml

## ✅ 테스트 내용
- [x] 고졸 사회 시험지 등록 후 미등록 목록에 정상 노출 확인
- [x] 중졸/고졸 동일 회차 데이터 간의 간섭 현상 해결 확인
- [x] 메인 대시보드 통계 수치와 실제 리스트 일치 확인

## 🔗 관련 이슈
closes #63 