### PR TITLE
[ENH] 시험지 등록 프로세스 내 검색 필터 및 업로드 설정 유지 기능 개선

### DIFF
--- a/src/main/webapp/resources/js/admin_main.js
+++ b/src/main/webapp/resources/js/admin_main.js
@@ -208,7 +208,7 @@ document.addEventListener('DOMContentLoaded', () => {
         analysisOptionsSection.style.display = hasFile ? 'block' : 'none'
 
         // 전체 초기화
-        clearPdfUploadSelectbox()
+        // clearPdfUploadSelectbox()
         
         // 파일 변경 시 시험 유형 옵션 다시 불러오기
         if(hasFile){
@@ -226,6 +226,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // PDF 시험지 정보 설정 
     fetchGetExamTypes() 
+
     selectExamType.addEventListener('change', (e) => {
         const selectedType = e.target.value 
 
@@ -514,8 +515,17 @@ const loadPdfFile = () => {
                 
                 // 시험지 목록 새로고침(특정 폴더 내에서 등록한 경우만 해당 폴더 시험지 목록 새로고침)
                 // 메인 페이지에서 바로 등록한 경우에는 폴더 리스트만 새로고침
+                
                 if(activeFolderId){
-                    loadExamListData(activeFolderId)
+                    if(isSearching){
+                        currentSearchPage = 1
+                        const searchParams = handleSearch()
+                        if(!searchParams) return
+    
+                        fetchSearchExams(searchParams)
+                    } else {
+                        loadExamListData(activeFolderId)
+                    }
                 }
 
                 // 폴더 리스트 새로고침
@@ -750,7 +760,15 @@ const fetchExamDelete = (examIds) => {
         .then(response => {
             if(response.data){
                 // 1. 시험지 목록 UI 업데이트
-                loadExamListData(activeFolderId)
+                if(isSearching){
+                    currentSearchPage = 1
+                    const searchParams = handleSearch()
+                    if(!searchParams) return
+
+                    fetchSearchExams(searchParams)
+                } else {
+                    loadExamListData(activeFolderId)
+                }
 
                 // 2. 폴더 목록 UI 업데이트
                 fetchFolderList()
@@ -1129,8 +1147,16 @@ const validateExamInfo = () => {
 const fetchGetExamTypes = () => {
     axios.get('/exam/getAllExamTypes')
         .then(response => {
-            selectExamType.innerHTML = updateExamTypes(response.data)
-            searchType.innerHTML = updateExamTypes(response.data)
+            const currentSelectVal = selectExamType.value
+            const currentSearchVal = searchType.value
+
+            if(!currentSearchVal || !isSearching){
+                searchType.innerHTML = updateExamTypes(response.data)
+            }
+
+            if(!currentSelectVal){
+                selectExamType.innerHTML = updateExamTypes(response.data)
+            }
         })
         .catch(error => {
             console.error('error: ', error)


### PR DESCRIPTION
## 📌 변경 사항
- **등록 모달 내 설정 보존**: PDF 파일 교체(`change`) 시 기존에 선택된 시험 유형, 과목 등의 설정값이 초기화되지 않도록 로직 수정
- **검색 필터 유지**: 새 시험지 등록 완료 후 검색 폼(`searchForm`)의 모든 값(시험 유형 포함)이 보존되도록 개선
- **목록 로드 분기 처리**: 등록 성공 후 `isSearching` 상태를 확인하여, 검색 중일 경우 기존 필터를 유지한 채 검색 결과 리스트(`fetchSearchExams`)를 호출하고 일반 모드일 경우 폴더 리스트(`loadExamListData`)를 호출하도록 수정

## 🛠️ 수정한 이유
- **반복 입력 방지**: 파일을 잘못 선택하여 교체할 때 이미 설정한 시험 정보가 초기화되어 처음부터 다시 선택해야 했던 번거로움을 해결하기 위함
- **작업 맥락(Context) 유지**: 특정 조건으로 검색하여 작업 중일 때, 등록 완료 후 필터가 풀리고 '전체 리스트'로 돌아가버려 발생하던 UX 흐름의 단절을 방지하기 위함

## 🔍 주요 변경 파일
- admin_main.js

## ✅ 테스트 내용
- [x] PDF 파일 선택 후 정보를 입력한 상태에서 다른 파일로 교체 시 설정값(유형, 과목 등) 유지 확인
- [x] 특정 키워드/유형으로 검색된 리스트에서 새 시험지 등록 후 검색 필터 및 결과 목록 유지 확인
- [x] 등록 모달 내의 하위 필드(과목 등)가 파일 교체 후에도 유효한 선택 상태를 유지하는지 확인

## 🔗 관련 이슈
closes #