### PR TITLE
[BUG] 공통 지문 업데이트 시 범위 내 전체 문항의 값을 일괄 수정하도록 개선

### DIFF
--- a/src/main/java/com/my/ex/dao/ExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/ExamSelectionDao.java
@@ -186,4 +186,9 @@ public class ExamSelectionDao implements IExamSelectionDao {
 		return session.selectList(NAMESPACE + "getMissingAnswerExams");
 	}
 
+	@Override
+	public void updateCommonPassageRange(ExamQuestionDto dto) {
+		session.update(NAMESPACE + "updateCommonPassageRange", dto);
+	}
+
 }

--- a/src/main/java/com/my/ex/dao/IExamSelectionDao.java
+++ b/src/main/java/com/my/ex/dao/IExamSelectionDao.java
@@ -44,4 +44,5 @@ public interface IExamSelectionDao {
 	List<ExamTitleDto> searchExams(ExamSearchDto dto);
 	int getTotalExamCount();
 	List<ExamInfoDto> getMissingAnswerExams();
+	void updateCommonPassageRange(ExamQuestionDto dto);
 }

--- a/src/main/java/com/my/ex/dto/ExamQuestionDto.java
+++ b/src/main/java/com/my/ex/dto/ExamQuestionDto.java
@@ -14,4 +14,5 @@ public class ExamQuestionDto {
 	private String individualPassage; 	// 단독 지문
 	private String commonPassage;		// 공통 지문
 	private String passageScope; 		// 지문 적용 범위 (예: [11~13])
+	private int[] rangeArray;
 }

--- a/src/main/java/com/my/ex/service/ExamSelectionService.java
+++ b/src/main/java/com/my/ex/service/ExamSelectionService.java
@@ -503,6 +503,7 @@ public class ExamSelectionService implements IExamSelectionService {
 		String examType = i.getTypeKor();
 		String examRound = i.getRound();
 		String examSubject = i.getSubject();
+		Integer examId = i.getExamId();
 
 		// 시험지
 		Integer questionid = q.getQuestionId();
@@ -512,6 +513,7 @@ public class ExamSelectionService implements IExamSelectionService {
 
 		// 시험지 객체에 데이터 파싱
 		ExamQuestionDto dto = new ExamQuestionDto();
+		dto.setExamId(examId);
 		dto.setQuestionId(questionid);
 		dto.setQuestionText(questionText);
 		if(useCommonPassage == 'Y') {
@@ -519,6 +521,7 @@ public class ExamSelectionService implements IExamSelectionService {
 			String type = commonPassage.getType();
 			String content = commonPassage.getContent();
 			String rangeText = commonPassage.getRangeText();
+			int[] rangeArray = commonPassage.getRangeArray();
 
 			String newContent = content;
 			if(type.equals("image")) {
@@ -548,6 +551,9 @@ public class ExamSelectionService implements IExamSelectionService {
 			}
 			dto.setCommonPassage(newContent);
 			dto.setPassageScope(rangeText);
+			dto.setRangeArray(rangeArray);
+
+			dao.updateCommonPassageRange(dto);
 		}
 
 		if(useIndividualPassage == 'Y') {

--- a/src/main/resources/mappers/ExamSelectionmapper.xml
+++ b/src/main/resources/mappers/ExamSelectionmapper.xml
@@ -414,6 +414,17 @@
 			   passage_scope = #{passageScope}
 		 WHERE question_id = #{questionId}
 	</update>
+
+	<update id="updateCommonPassageRange" parameterType="ExamQuestionDto">
+			UPDATE exam_question
+			   SET commonpassage = #{commonPassage},
+				   passage_scope = #{passageScope}
+			 WHERE exam_id = #{examId}
+			   AND question_num IN
+		       <foreach collection="rangeArray" item="num" open="(" separator="," close=")">
+				   #{num}
+			   </foreach>
+	</update>
 	
 	<!-- 시험지 단일 문항 선택지 수정 -->
 	<update id="updateQuestionChoices" parameterType="ExamChoiceDto">


### PR DESCRIPTION
## 📌 변경 사항
- **공통 지문 일괄 업데이트 로직 도입**: 특정 문항의 공통 지문 수정 시, 해당 범위(`rangeArray`)에 속한 모든 문항의 `commonpassage`와 `passage_scope`가 동시에 변경되도록 수정
- **MyBatis `<foreach>` 활용**: `exam_id`와 `question_num`을 조건으로 하는 배치 업데이트 쿼리(`updateCommonPassageRange`) 추가
- **로직 분리**: 단일 문항의 기본 정보 수정과 공통 범위 데이터 동기화 로직을 분리하여 데이터 무결성 확보

## 🛠️ 수정한 이유
- **데이터 불일치 해결**: 기존에는 수정 중인 단일 문항만 업데이트되어, 동일 범위 내 다른 문항들은 과거 지문을 유지하는 결함이 있었음
- **UI 중복 노출 방지**: 데이터 불일치로 인해 화면상에 동일 범위에 대한 '수정 전'과 '수정 후' 지문 2개가 동시에 렌더링되는 버그를 해결하기 위함
- **관리자 편의성**: 범위 내 모든 문항을 일일이 수정해야 하는 번거로움을 없애고 작업 신뢰도를 높임

## 🔍 주요 변경 파일
- ExamSelectionService.java
- ExamSelectionmapper.xml

## ✅ 테스트 내용
- [x] 단일 문항에서 공통 지문 수정 시, 수정하지 않은 문항들의 지문도 정상 변경되는지 확인
- [x] 지문 수정 후 상세 페이지 및 리스트에서 지문이 중복 노출되지 않고 1개만 정상 표시되는지 확인
- [x] 공통 지문이 없는 일반 문항의 경우 기존처럼 단일 수정이 정상 동작하는지 확인

## 🔗 관련 이슈
closes #67 