### PR TITLE
[BUG] PDF 파싱 시 이전 문항의 공통 지문 데이터 초기화 누락 수정

### DIFF
--- a/src/main/java/com/my/ex/parser/geomjeong/parse/exam/GeomjeongExamParser.java
+++ b/src/main/java/com/my/ex/parser/geomjeong/parse/exam/GeomjeongExamParser.java
@@ -152,6 +152,18 @@ public class GeomjeongExamParser implements IExamParser {
 	        Matcher numMatcher = Pattern.compile("^(\\d+)\\.\\s*([\\s\\S]*)", Pattern.DOTALL).matcher(trimmedBlock);
 	        
 	        if(numMatcher.find()) {
+	        	int targetNum = Integer.parseInt(numMatcher.group(1));
+	        	
+	        	String[] scopeParts = currentPassageScope.split("[~～]");
+	        	// 현재 문제 번호가 지문 적용 범위를 벗어나면 공통 지문 초기화
+	            if (scopeParts.length == 2) {
+	                int scopeEnd = Integer.parseInt(scopeParts[1].trim());
+	                if (targetNum > scopeEnd) {
+	                    currentCommonPassage = "";
+	                    currentPassageScope = "";
+	                }
+	            }
+	        	
 	            if (!nextCommonPassage.isEmpty()) {
 	                currentCommonPassage = nextCommonPassage;
 	                currentPassageScope = nextPassageScope;


### PR DESCRIPTION
## 📌 변경 사항
- **파싱 초기화 로직 추가**: `GeomjeongExamParser.java` 내 문항 반복문(loop) 시작 시점에 공통 지문 관련 변수(`commonpassage`, `passageScope` 등)를 명시적으로 초기화하도록 수정

## 🛠️ 수정한 이유
- 시험지 PDF 업로드 시, 공통 지문이 포함된 문항 다음의 일반 문항(지문 없음)을 파싱할 때 이전 문항의 지문 데이터가 변수에 남아있었음
- 이로 인해 데이터베이스에 잘못된 지문 정보가 중복 등록되어 데이터 무결성이 깨지는 문제를 해결하기 위함

## 🔍 주요 변경 파일
- GeomjeongExamParser.java

## ✅ 테스트 내용
- [x] 공통 지문이 포함된 PDF 업로드 후 파싱 결과 확인
- [x] 지문이 없는 일반 문항에 이전 문항의 지문 데이터가 전이되지 않는지 확인
- [x] DB 저장 후 `common_passage` 테이블 및 문항 테이블 간의 연관 관계 정상 등록 확인

## 🔗 관련 이슈
closes #69 