### PR TITLE
[FEAT] 관리자 검토 페이지 상단 이동 버튼 추가

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/exam_page.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/exam_page.jsp
@@ -178,6 +178,10 @@
             </c:forEach>
         </div>
         
+        <button id="btn-back-to-top" title="맨 위로 이동">
+		    <i class="fas fa-arrow-up"></i>
+		</button>
+        
     </div>
 
     <script src="<c:url value='/resources/js/admin_exam_page.js'/>"></script>

--- a/src/main/webapp/resources/css/admin_exam_page.css
+++ b/src/main/webapp/resources/css/admin_exam_page.css
@@ -317,6 +317,34 @@ body {
     color: inherit !important; 
 }
 
+/* 맨 위로 버튼 */
+#btn-back-to-top {
+    display: none;      
+    position: fixed;      
+    bottom: 30px;        
+    right: 30px;        
+    z-index: 999;       
+    border: none;
+    outline: none;
+    background-color: #3498db; 
+    cursor: pointer;
+    padding: 15px;
+    border-radius: 50%;   
+    width: 50px;
+    height: 50px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+    transition: opacity 0.3s, background-color 0.3s;
+
+    color: white;
+    justify-content: center;
+    align-items: center;
+}
+
+#btn-back-to-top:hover {
+    background-color: #2980b9;
+}
+
+
 /* Responsive (모바일) */
 @media (max-width: 768px) {
     .review-container {
@@ -355,5 +383,13 @@ body {
     .btn-edit-question {
         padding: 6px 12px;
         font-size: 0.85em;
+    }
+
+    #btn-back-to-top {
+        bottom: 20px;
+        right: 20px;
+        width: 40px;
+        height: 40px;
+        padding: 10px;
     }
 }

--- a/src/main/webapp/resources/js/admin_exam_page.js
+++ b/src/main/webapp/resources/js/admin_exam_page.js
@@ -12,6 +12,24 @@ document.addEventListener('DOMContentLoaded', () => {
             location.href = `/exam/editQuestion/${questionId}/${examId}`
         })
     })
-    
+
+    // 맨 위로 버튼
+    const topBtn = document.querySelector("#btn-back-to-top")
+
+    // 스크롤 감지: 300px 이상 내려오면 버튼 표시
+    window.onscroll = () => {
+        if (document.body.scrollTop > 300 || document.documentElement.scrollTop > 300) {
+            topBtn.style.display = "flex";
+        } else {
+            topBtn.style.display = "none";
+        }
+    }
+
+    topBtn.addEventListener('click', () => {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        })
+    })
 })
 


### PR DESCRIPTION
## 📌 변경 사항
- **상단 이동(Back to Top) 버튼 구현**: 관리자 시험지 검토 페이지 우측 하단에 고정된 위치의 플로팅 버튼을 추가
- **스크롤 이벤트 연동**: 일정 거리 이상 스크롤 시 버튼이 나타나고, 클릭 시 페이지 최상단으로 부드럽게 이동하는 스크립트를 적용

## 🛠️ 수정한 이유
- 시험 문항이 많은 경우 페이지의 길이가 매우 길어지며, 검토 후 상단 내비게이션으로 돌아가기 위한 불필요한 스크롤 동작이 반복되는 불편함을 개선하고자 함

## 🔍 주요 변경 파일
- /admin/exam_page.jsp
- admin_exam_page.css
- admin_exam_page.js

## ✅ 테스트 내용
- [x] 스크롤 하강 시 버튼이 정상적으로 노출되는지 확인
- [x] 버튼 클릭 시 페이지 최상단으로 즉시 이동하는지 확인

## 🔗 관련 이슈
closes #70 